### PR TITLE
fix broken wordpress links in getting started

### DIFF
--- a/getting_started/documents_and_forms.rst
+++ b/getting_started/documents_and_forms.rst
@@ -1,3 +1,5 @@
+.. _documents-and-forms:
+
 ******************************* 
 Documents and Forms
 *******************************
@@ -10,13 +12,13 @@ Forms for Requesting a Project Allocation
 Use this form to request a Director's Discretionary (DD) Project.
 
 `Principal Investigator
-Agreement </wp-content/accounts/PI_Agreement.pdf>`_ The Oak Ridge
+Agreement <https://www.olcf.ornl.gov/wp-content/accounts/PI_Agreement.pdf>`_ The Oak Ridge
 Leadership Computing Facility must have a signed copy of this form on
 file from the project's principal investigator(s) before any accounts
 for the project will be processed.
 
 `Industry Principal Investigator's
-Agreement </wp-content/accounts/Industry_PI_Agreement.pdf>`_ The Oak
+Agreement <https://www.olcf.ornl.gov/wp-content/accounts/Industry_PI_Agreement.pdf>`_ The Oak
 Ridge Leadership Computing Facility must have a signed copy of this form
 on file from the project's principal investigator(s) before any accounts
 for the project will be processed.
@@ -26,12 +28,12 @@ for the project will be processed.
 Forms for Requesting an Account
 ===============================
 
-`Request anAccount </for-users/documents-forms/olcf-account-application/>`_
+`Request an Account <https://www.olcf.ornl.gov/for-users/documents-forms/olcf-account-application/>`_
 Use this form to request a new user account or join an additional project.
 
 `Notary Token Verification
-Form </wp-content/accounts/Notary_Token_Verification_Form.pdf>`_ (See
-`Notary Instructions </wp-content/accounts/Notary_Instructions.pdf>`__)
+Form <https://www.olcf.ornl.gov/wp-content/accounts/Notary_Token_Verification_Form.pdf>`_ (See
+`Notary Instructions <https://www.olcf.ornl.gov/wp-content/accounts/Notary_Instructions.pdf>`__)
 For certain resources, ORNL requires identity proofing to authenticate a
 user’s identity and possession of the token prior to activation. The
 Notary Token Verification Form verifies the identity of the applicant
@@ -40,10 +42,10 @@ disclosed in the future to an authorized individual or investigative
 agency.
 
 `Nondisclosure Agreement
-Form </wp-content/accounts/OLCF_NDA.pdf>`_ Required from
+Form <https://www.olcf.ornl.gov/wp-content/accounts/OLCF_NDA.pdf>`_ Required from
 subcontractors only.
 
-`Sensitive DataRules </wp-content/accounts/Sensitive_Data_Rules.pdf>`_
+`Sensitive DataRules <https://www.olcf.ornl.gov/wp-content/accounts/Sensitive_Data_Rules.pdf>`_
 All users
 must agree to abide by all security measures described in this document
 when performing any work on OLCF resources that is not fundamental
@@ -55,18 +57,18 @@ Forms to Request Changes to Computers, Jobs, or Accounts
 ========================================================
 
 `Software Installation Request
-Form </support/software/software-request>`_
+Form <https://www.olcf.ornl.gov/support/software/software-request>`_
 Use this form to request
 a software/library/application installation on a center computer.
 
 `Relaxed Queue Limit Request
-Form </user-support-overview/getting-started/special-request-form/>`_
+Form <https://www.olcf.ornl.gov/user-support-overview/getting-started/special-request-form/>`_
 Use this form to request deviations from the standard batch queue
 policy. Typical requests would be for increased priority for one (or
 several) jobs or an increased wall-time limit.
 
 `System Reservation Request
-Form </user-support-overview/getting-started/special-request-form/>`_
+Form <https://www.olcf.ornl.gov/user-support-overview/getting-started/special-request-form/>`_
 Use this form to request dedicated access to some or all of a machine.
 If granted, no other users/projects will be running on the processors
 that have been reserved. Please note that if granted, your project will
@@ -81,11 +83,11 @@ Additionally, the reservation differs from traditional batch jobs in the
 way it is charged against an allocation (described above).
 
 `Disk Quota Increase Request
-Form </user-support-overview/getting-started/special-request-form/>`_
+Form <https://www.olcf.ornl.gov/user-support-overview/getting-started/special-request-form/>`_
 Use this form to request an increased disk quota.
 
 `Purge Exemption Request
-Form </user-support-overview/getting-started/special-request-form/>`_
+Form <https://www.olcf.ornl.gov/user-support-overview/getting-started/special-request-form/>`_
 Use this form to request temporary relief from the scratch disk purge.
 
 --------------
@@ -93,12 +95,12 @@ Use this form to request temporary relief from the scratch disk purge.
 Report Templates
 ================
 
-`Closeout Report Template </wp-content/accounts/Closeout_Template.doc>`_
+`Closeout Report Template <https://www.olcf.ornl.gov/wp-content/accounts/Closeout_Template.doc>`_
 Use this
 template if you have been asked to submit a closeout report for your
 project.
 
-`Industry Quarterly Report Template </wp-content/accounts/industry_quarterly_report.doc>`_
+`Industry Quarterly Report Template <https://www.olcf.ornl.gov/wp-content/accounts/industry_quarterly_report.doc>`_
 Use
 this template if you have an industry project to submit a quarterly
 report.
@@ -108,5 +110,5 @@ report.
 Miscellaneous Forms
 ===================
 
-`Director's Discretion Review Form </wp-content/accounts/dd_review.pdf>`_
+`Director's Discretion Review Form <https://www.olcf.ornl.gov/wp-content/accounts/dd_review.pdf>`_
 For internal use only.

--- a/getting_started/documents_and_forms.rst
+++ b/getting_started/documents_and_forms.rst
@@ -45,7 +45,7 @@ agency.
 Form <https://www.olcf.ornl.gov/wp-content/accounts/OLCF_NDA.pdf>`_ Required from
 subcontractors only.
 
-`Sensitive DataRules <https://www.olcf.ornl.gov/wp-content/accounts/Sensitive_Data_Rules.pdf>`_
+`Sensitive Data Rules <https://www.olcf.ornl.gov/wp-content/accounts/Sensitive_Data_Rules.pdf>`_
 All users
 must agree to abide by all security measures described in this document
 when performing any work on OLCF resources that is not fundamental

--- a/getting_started/frequently_asked_questions.rst
+++ b/getting_started/frequently_asked_questions.rst
@@ -6,9 +6,8 @@ How do I apply for an account?
 =================================
 
 Detailed instructions for account application can be found in the
-`'Applying For a User
-Account' </for-users/getting-started/#applying-for-a-user-account>`__
-section of the `Getting Started </for-users/getting-started>`__ page.
+:ref:`applying-for-a-user-account`
+section of the :ref:`getting-started-at-the-olcf` page.
 
 What is the status of my application?
 =======================================
@@ -86,10 +85,9 @@ statement <https://www.emc.com/collateral/legal/token-disposal-statement.pdf>`__
 Additional Resources
 =======================
 
-We're here to provide support at every step. We also provide a
-collection of `Tutorials </for-users/training/tutorials/>`__ for applied
-technical demonstrations, `System User
-Guides </for-users/system-user-guides/>`__, `Training
-Events </for-users/training/>`__, and the `User Assistance
-Center </for-users/user-assistance/>`__ to answer questions and resolve
-technical issues as they arise.
+We're here to provide support at every step. We also provide a collection of
+`Tutorials <https://www.olcf.ornl.gov/for-users/training/tutorials/>`__ for
+applied technical demonstrations, :ref:`system-user-guides`, `Training Events
+<https://www.olcf.ornl.gov/for-users/training/>`__, and the `User Assistance
+Center <https://www.olcf.ornl.gov/for-users/user-assistance/>`__ to answer
+questions and resolve technical issues as they arise.

--- a/getting_started/getting_started.rst
+++ b/getting_started/getting_started.rst
@@ -38,10 +38,11 @@ required from industrial Director's Discretion projects only.
 +--------------------------+----------------------------------------------------+--------------------------------------------------------------------------------+--------------------------------------------------------------------------------+
 | **Quarterly Reports**    | yes                                                | no*                                                                            | yes                                                                            |
 +--------------------------+----------------------------------------------------+--------------------------------------------------------------------------------+--------------------------------------------------------------------------------+
-| **Where to apply**       | `Apply for INCITE                                  | `Apply for DD                                                                  | `Apply for ALCC                                                                |
-|                          | <https://proposals.doeleadershipcomputing.org/>`__ | </for-users/documents-forms/olcf-directors-discretion-project-application/>`__ | <http://science.energy.gov/ascr/facilities/accessing-ascr-facilities/alcc/>`__ |
+| **Where to apply**       | `Apply for INCITE                                  | `Apply for DD`_                                                                | `Apply for ALCC                                                                |
+|                          | <https://proposals.doeleadershipcomputing.org/>`__ |                                                                                | <http://science.energy.gov/ascr/facilities/accessing-ascr-facilities/alcc/>`__ |
 +--------------------------+----------------------------------------------------+--------------------------------------------------------------------------------+--------------------------------------------------------------------------------+
 
+.. _Apply for DD: https://www.olcf.ornl.gov/for-users/documents-forms/olcf-directors-discretion-project-application/
  
 
 What are the differences between project types?
@@ -79,12 +80,12 @@ productivity on leadership computing platforms. The OLCF Resource
 Utilization Council, as well as independent referees, review and approve
 all DD requests. Applications are accepted year round via the `OLCF
 Director's Discretion Project
-Application </for-users/documents-forms/olcf-directors-discretion-project-application/>`__.
+Application <https://www.olcf.ornl.gov/for-users/documents-forms/olcf-directors-discretion-project-application/>`__.
 
 **Vendor –** OLCF resources are also available to ORNL vendors.
 Applications may be submitted year round by completing the `Vendor
 Project
-Application </support/getting-started/olcf-vendor-project-application/>`__.
+Application <https://www.olcf.ornl.gov/support/getting-started/olcf-vendor-project-application/>`__.
 
     If you have questions about project types or application procedures,
     feel free to contact the OLCF Accounts Team at accounts@ccs.ornl.gov.
@@ -136,8 +137,9 @@ InfiniBand interconnect. The OLCF Director's Discretionary (DD) program
 allocates approximately 10% of the available Summit hours in a calendar
 year. **Summit is allocated in *node* hours, and a typical DD project is
 awarded between 15,000 - 20,000 *node* hours.** For more information
-about Summit, please visit the `Summit User
-Guide </for-users/system-user-guides/summit>`__.
+about Summit, please visit the :ref:`summit-user-guide`.
+
+.. _applying-for-a-user-account:
 
 Applying for a user account
 ================================
@@ -156,7 +158,7 @@ receiving a user account, and we're here to help you through them.
     Account Application and indicate you are an existing user.
 
 #. Apply for an account using the `Account Request
-   Form </support/getting-started/olcf-account-application>`__.
+   Form <https://www.olcf.ornl.gov/support/getting-started/olcf-account-application>`__.
 #. The principal investigator (PI) of the project must approve your
    account and system access. The Accounts Team will contact the PI for
    this approval.
@@ -179,8 +181,7 @@ created and you will be notified by email. Now that you have a user
 account and it has been associated with a project, you're ready to get
 to work. This website provides extensive documentation for OLCF systems,
 and can help you efficiently use your project's allocation. We recommend
-reading the `System User Guides </for-users/system-user-guides/>`__ for
-the machines you will be using often.
+reading the :ref:`system-user-guides` for the machines you will be using often.
 
 Systems Available to All Projects
 ======================================

--- a/getting_started/index.rst
+++ b/getting_started/index.rst
@@ -1,3 +1,5 @@
+.. _getting-started-at-the-olcf:
+
 ############################
 Getting Started at the OLCF
 ############################
@@ -13,10 +15,9 @@ Getting Started at the OLCF
 Additional Resources
 ======================
 
-We're here to provide support at every step. We also provide a
-collection of `Tutorials </for-users/training/tutorials/>`__ for applied
-technical demonstrations, `System User
-Guides </for-users/system-user-guides/>`__, `Training
-Events </for-users/training/>`__, and the `User Assistance
-Center </for-users/user-assistance/>`__ to answer questions and resolve
-technical issues as they arise.
+We're here to provide support at every step. We also provide a collection of
+`Tutorials <https://www.olcf.ornl.gov/for-users/training/tutorials/>`__ for
+applied technical demonstrations, :ref:`system-user-guides`, `Training Events
+<https://www.olcf.ornl.gov/for-users/training/>`__, and the `User Assistance
+Center <https://www.olcf.ornl.gov/for-users/user-assistance/>`__ to answer
+questions and resolve technical issues as they arise.

--- a/getting_started/olcf_policy_guide.rst
+++ b/getting_started/olcf_policy_guide.rst
@@ -622,14 +622,13 @@ for assistance. Most new implementations support this authentication
 type, and many ssh clients are available on the web. Login sessions will
 be automatically terminated after a period of inactivity. When you apply
 for an account, you will be mailed an RSA SecurID token. You will also
-be sent a request to complete identity verification. When your account
-is approved, your RSA SecurID token will also be enabled. Please refer
-to `OLCF System User Guides </for-users/system-user-guides/>`__ for more
-information on host access. DO NOT share your PIN or RSA SecurID token
-with anyone. Sharing of accounts will result in termination. If your
-SecurID token is stolen or misplaced, contact the OLCF immediately and
-report the missing token. Upon termination of your account access,
-return the token to the OLCF in person or via mail.
+be sent a request to complete identity verification. When your account is
+approved, your RSA SecurID token will also be enabled. Please refer to our
+:ref:`system-user-guides` for more information on host access. DO NOT share your
+PIN or RSA SecurID token with anyone. Sharing of accounts will result in
+termination. If your SecurID token is stolen or misplaced, contact the OLCF
+immediately and report the missing token. Upon termination of your account
+access, return the token to the OLCF in person or via mail.
 
 Data Management
 ---------------
@@ -659,12 +658,11 @@ apply to sensitive data:
 Data Transfer
 -------------
 
-The OLCF offers two dedicated data transfer nodes to users. The nodes
-have been tuned specifically for wide area data transfers, and also
-perform well on the local area. There are also several utilities that
-the OLCF recommends for data transfer. Please refer to our `System User
-Guides </for-users/system-user-guides/>`__ for information about the
-DTNs and available utilities.
+The OLCF offers two dedicated data transfer nodes to users. The nodes have been
+tuned specifically for wide area data transfers, and also perform well on the
+local area. There are also several utilities that the OLCF recommends for data
+transfer. Please refer to our :ref:`system-user-guides` for information about
+the DTNs and available utilities.
 
 Titan Scheduling Policy
 =======================
@@ -712,10 +710,10 @@ However, several factors are applied by the batch system to modify the
 -  The 8-week history of usage for the project associated with the job.
 -  The 8-week history of usage for the user associated with the job.
 
-If your jobs require resources outside these queue policies, please
-complete the relevant request form on the `Special
-Requests </support/getting-started/special-request-form/>`__ page. If
-you have any questions or comments on the queue policies below, please
+If your jobs require resources outside these queue policies, please complete the
+relevant request form on the `Special Requests
+<https://www.olcf.ornl.gov/support/getting-started/special-request-form/>`__
+page. If you have any questions or comments on the queue policies below, please
 direct them to the User Assistance Center.
 
 Job Priority by Processor Count
@@ -847,7 +845,7 @@ System Reservation Policy
 
 Projects may request to reserve a set of processors for a period of time
 through the reservation request form, which can be found on the `Special
-Requests <http://www.olcf.ornl.gov/support/getting-started/special-request-form/>`__
+Requests <https://www.olcf.ornl.gov/support/getting-started/special-request-form/>`__
 page. If the reservation is granted, the reserved processors will be
 blocked from general use for a given period of time. Only users that
 have been authorized to use the reservation can utilize those resources.
@@ -1001,9 +999,8 @@ Intellectual Property
 Special Requests and Policy Exemptions
 ======================================
 
-To request policy exemptions, please submit the appropriate webform
-available on the `Documents and Forms </for-users/documents-forms/>`__
-page. Special request forms allow a user to:
+To request policy exemptions, please submit the appropriate webform available on
+the :ref:`documents-and-forms` page. Special request forms allow a user to:
 
 -  Request Software installations
 -  Request relaxed queue limits for a job

--- a/systems/index.rst
+++ b/systems/index.rst
@@ -1,9 +1,11 @@
-################
-Systems at OLCF
-################
+.. _system-user-guides:
+
+###################
+System User Guides
+###################
 
 .. toctree::
    :maxdepth: 2
-    
+
    summit_user_guide
    rhea_user_guide

--- a/systems/rhea_user_guide.rst
+++ b/systems/rhea_user_guide.rst
@@ -1766,11 +1766,11 @@ Remote Visualization using VNC (non-GPU)
 ----------------------------------------
 
 In addition to the instructions below, `Benjamin
-Hernandez </directory/staff-member/benjamin-hernandez/>`__ of the `OLCF
+Hernandez <https://www.olcf.ornl.gov/directory/staff-member/benjamin-hernandez/>`__ of the `OLCF
 Advanced Data and Workflows
-Group </about-olcf/olcf-groups/advanced-data-and-workflows/>`__
+Group <https://www.olcf.ornl.gov/about-olcf/olcf-groups/advanced-data-and-workflows/>`__
 presented a related talk, `GPU Rendering in Rhea and
-Titan </wp-content/uploads/2016/01/GPURenderingRheaTitan-1.pdf>`__,
+Titan <https://www.olcf.ornl.gov/wp-content/uploads/2016/01/GPURenderingRheaTitan-1.pdf>`__,
 during the 2016 OLCF User Meeting.
 
 step 1 (local system)

--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -1,3 +1,5 @@
+.. _summit-user-guide:
+
 ******************
 Summit User Guide
 ******************


### PR DESCRIPTION
Partially addresses #10.
This fixes all of the external links in the "Getting Started" pages, and most of the internal links as well. The only ones I noticed that are not fixed by this PR are those referencing file systems and DTNs, as we do not have the local "Data" pages installed yet.