### PR TITLE
Removes broken link to additional bsub info

### DIFF
--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -1540,8 +1540,7 @@ script. If conflicting options are specified (i.e. different walltime
 specified on the command line versus in the script), the option on the
 command line takes precedence. Note that LSF has numerous options; only
 the most common ones are described here. For more in-depth information
-about other LSF options, see the
-`documentation <#for-more-information>`__.
+about other LSF options, see the ``bsub`` man page.
 
 +--------------------+----------------------------------------+----------------------------------------------------------------------------------+
 | Option             | Example Usage                          | Description                                                                      |


### PR DESCRIPTION
Changes wording to direct readers to the `bsub` man page for additional info.