### PR TITLE
WIP: put training into sidebar

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -42,11 +42,10 @@ Software
 Training
 ---------
 
-* `Tutorials <https://www.olcf.ornl.gov/for-users/training/tutorials/>`_
-* `Archive <https://www.olcf.ornl.gov/for-users/training/training-archive/>`_
-* `Calendar <https://www.olcf.ornl.gov/for-users/training/training-calendar/>`_
-* `Hackathons <https://www.olcf.ornl.gov/for-users/training/gpu-hackathons/>`_
-* `OLCF Training Channel <https://vimeo.com/channels/olcftraining>`_
+.. toctree::
+   :maxdepth: 2
+
+   training/index.rst
 
 How to contribute to this documentation
 -----------------------------------------

--- a/training/index.rst
+++ b/training/index.rst
@@ -1,0 +1,13 @@
+.. _training:
+
+#########
+Training
+#########
+
+
+* `Tutorials <https://www.olcf.ornl.gov/for-users/training/tutorials/>`_
+* `Archive <https://www.olcf.ornl.gov/for-users/training/training-archive/>`_
+* `Calendar <https://www.olcf.ornl.gov/for-users/training/training-calendar/>`_
+* `Hackathons <https://www.olcf.ornl.gov/for-users/training/gpu-hackathons/>`_
+* `OLCF Training Channel <https://vimeo.com/channels/olcftraining>`_
+


### PR DESCRIPTION
For consistency, all top-level sections should be in the sidebar. Since there is nothing from "training" locally hosted, this just goes to a page with the external links. Other suggestions welcome.

Closes #46 