### PR TITLE
Corrects training link to OLCF-Tutorials on GitHub

### DIFF
--- a/training/index.rst
+++ b/training/index.rst
@@ -5,7 +5,7 @@ Training
 #########
 
 
-* `Tutorials <https://www.olcf.ornl.gov/for-users/training/tutorials/>`_
+* `Tutorials <https://github.com/olcf-tutorials>`_
 * `Archive <https://www.olcf.ornl.gov/for-users/training/training-archive/>`_
 * `Calendar <https://www.olcf.ornl.gov/for-users/training/training-calendar/>`_
 * `Hackathons <https://www.olcf.ornl.gov/for-users/training/gpu-hackathons/>`_


### PR DESCRIPTION
Resolves #75. There are newer/more relevant tutorials on the OLCF-Tutorials GH org.