### PR TITLE
Updates CSS theme overrides.

### DIFF
--- a/_static/css/theme_overrides.css
+++ b/_static/css/theme_overrides.css
@@ -1,3 +1,11 @@
+.wy-side-nav-search, .wy-nav-top {
+   background: #007833;
+}
+
+.wy-nav-content {
+   max-width: 1200px;
+}
+
 /* override table width restrictions */
 @media screen and (min-width: 767px) {
 

--- a/_static/width.css
+++ b/_static/width.css
@@ -1,4 +1,0 @@
-/* make the content the full page width */
-.wy-nav-content {
-    max-width: 1200px;
-}

--- a/_templates/layout.html
+++ b/_templates/layout.html
@@ -1,17 +1,6 @@
 {% extends "!layout.html" %}
 {% block extrahead %}
-    <link href="{{ pathto("_static/width.css", True) }}" rel="stylesheet" type="text/css">
 {% endblock %}
 {% block footer %} {{ super() }}
 
-<style>
-/* Sidebar header (and topbar for mobile) */
-.wy-side-nav-search, .wy-nav-top {
-    background: #007833;
-}
-/* Sidebar */
-/* .wy-nav-side {
-    background: #000000;
-} */
-</style>
 {% endblock %}

--- a/conf.py
+++ b/conf.py
@@ -59,11 +59,9 @@ html_theme = 'sphinx_rtd_theme'
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ['_static']
 
-html_context = {
-    'css_files': [
-        '_static/theme_overrides.css',  # override wide tables in RTD theme
-    ],
-}
+html_css_files = [
+    'css/theme_overrides.css',
+]
 
 # see https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html
 html_theme_options = {


### PR DESCRIPTION
This commit replaces hardcoded template styling blocks and stylesheet
references generated by injecting them into the HTML template context
with having all stylesheets applied by the theme engine according to the
[theme documentation for adding custom CSS](https://docs.readthedocs.io/en/latest/guides/adding-custom-css.html)
and the associated [Sphinx custom CSS configuration documentation](https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_css_files).

In conjunction with this change, all the custom styles are merged into a
single stylesheet and style blocks have been removed from the page
templates.