### PR TITLE
Add body text to landing page

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -3,8 +3,14 @@
    completely to your liking, but it should at least contain the root `toctree`
    directive.
 
-Welcome to the OLCF User Documentation!
-===================================================
+OLCF User Documentation
+=======================
+
+This technical documentation is a reference guide for the user community
+to efficiently use OLCF compute and storage resources.
+
+.. note::
+    Suggestions and contributions are welcomed! See :doc:`contributing/index`.
 
 Accounts
 ---------

--- a/index.rst
+++ b/index.rst
@@ -6,11 +6,12 @@
 OLCF User Documentation
 =======================
 
-This technical documentation is a reference guide for the user community
-to efficiently use OLCF compute and storage resources.
+This technical documentation is a reference for the user community to
+efficiently use OLCF compute and storage resources.
 
-.. note::
-    Suggestions and contributions are welcomed! See :doc:`contributing/index`.
+Have an idea to improve this documentation? See :doc:`contributing/index`.
+
+Have a question? We're here to help -- help\@olcf.ornl.gov.
 
 Accounts
 ---------


### PR DESCRIPTION
The landing `index.rst` for the User Docs feels a bit empty. Here's a minimalistic first effort... any others have thoughts?