### PR TITLE
Clarify Summit login node cgroup policy

### DIFF
--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -1178,6 +1178,7 @@ job will run on the login node. If this happens, your job will interfere with
 
 Per-User Login Node Resource Limits
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Because the login nodes are resources shared by all Summit users, we utilize
 ``cgroups`` to help better ensure resource availability for all users of the
 shared nodes. By default each user is limited to **8 hardware-threads**, **8GB
@@ -1185,14 +1186,10 @@ of memory**, and **1 GPU**.  Please note that limits are set per user and not
 individual login sessions. All user processes on a node are contained within a
 single cgroup and share the cgroup's limits.
 
-In addition to the default settings, once one of a user’s processes on a node
-reaches 4-hours of CPU-time, all of the user’s processes will be limited to **.5
-hardware-thread**. If a process from any of a user’s login sessions reaches
-4-hours of CPU-time, all login sessions will be limited to .5 hardware-thread.
-To reset the cgroup limits on a node to default once the 4-hour reduction has
-been reached, you do not need to log out and back in, but will need to start a
-new login session to the node.
-
+If a process from any of a user’s login sessions reaches 4-hours of CPU-time,
+all login sessions will be limited to **.5 hardware-thread**.  To reset the
+cgroup limits on a node to default once the 4-hour CPU-time reduction has been
+reached, kill the offending process and start a new login session to the node.
 
     .. note:: Login node limits are set per user and not per individual login
         session.  All user processes on a node are contained within a single cgroup


### PR DESCRIPTION
New `cgroups` policies are difficult to describe. Hopefully this PR clears things up a little bit.