### PR TITLE
Adds `Edit on GitHub` button alongside OLCF home page navigation

### DIFF
--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -1,4 +1,12 @@
+/*
 $( document ).ready(function() {
   $(".wy-breadcrumbs-aside a").text("Go to OLCF Main Site");
   $(".wy-breadcrumbs-aside a").attr("href", "https://www.olcf.ornl.gov").attr("target","_blank");
 });
+
+$( document ).ready(function() {
+  var olcf_site = "OLCF Main Site";
+  $(".wy-breadcrumbs-aside").text($(".wy-breadcrumbs-aside a").text() + " | " + olcf_site);
+  $(".wy-breadcrumbs-aside a").attr("href", "https://www.olcf.ornl.gov").attr("target","_blank");
+});
+*/

--- a/_static/js/custom.js
+++ b/_static/js/custom.js
@@ -1,12 +1,20 @@
-/*
 $( document ).ready(function() {
-  $(".wy-breadcrumbs-aside a").text("Go to OLCF Main Site");
-  $(".wy-breadcrumbs-aside a").attr("href", "https://www.olcf.ornl.gov").attr("target","_blank");
-});
+  // Create link and text for navigation back to the OLCF home page
+  var olcf_link = document.createElement("a");
+  var olcf_text = document.createTextNode("OLCF Home Page");
+  olcf_link.appendChild(olcf_text);
+  olcf_link.setAttribute("href", "https://olcf.ornl.gov");
 
-$( document ).ready(function() {
-  var olcf_site = "OLCF Main Site";
-  $(".wy-breadcrumbs-aside").text($(".wy-breadcrumbs-aside a").text() + " | " + olcf_site);
-  $(".wy-breadcrumbs-aside a").attr("href", "https://www.olcf.ornl.gov").attr("target","_blank");
+  // Open OLCF home page in new tab when clicked
+  olcf_link.setAttribute("target","_blank");
+
+  var separator = document.createTextNode(" | ");
+
+  // These items are right-aligned in the RTD theme breadcrumbs
+  aside = document.querySelector("body > div > section > div > div > div:nth-child(1) > ul > li.wy-breadcrumbs-aside");
+
+  // Next to the default "Edit on GitHub", add a separator, then the OLCF link.
+  aside.appendChild(separator);
+  aside.appendChild(olcf_link);
+
 });
-*/

--- a/conf.py
+++ b/conf.py
@@ -67,13 +67,22 @@ html_js_files = [
     'js/custom.js',
 ]
 
+html_context = {
+    'vcs_pageview_mode': 'edit',
+    'display_github': True,
+    'github_user': 'olcf', # Username
+    'github_repo': 'olcf-user-docs', # Repo name
+    'github_version': 'master', # Version
+    'conf_py_path': '/', # Path in the checkout to the docs root
+}
+
 # see https://sphinx-rtd-theme.readthedocs.io/en/stable/configuring.html
 html_theme_options = {
     'canonical_url': 'https://docs.olcf.ornl.gov',
     'collapse_navigation': False,
     'sticky_navigation': True,
     'navigation_depth': 4,
-    'style_external_links': True
+    'style_external_links': True,
 }
 
 


### PR DESCRIPTION
This PR makes it easier for readers to propose improvements or directly contribute documentation corrections via the familiar "Edit on GitHub" button in the upper-right corner of each page.

Clicking this "Edit on GitHub" link will redirect to the current page's `.rst` file in this repository, and if the edit (pencil icon) button is clicked, a fork of the repository will automatically be made to facilitate making a PR.

This PR maintains the existing "OLCF Home Page" navigation button on each page.