### PR TITLE
add some best practices for submitting tickets

### DIFF
--- a/accounts/frequently_asked_questions.rst
+++ b/accounts/frequently_asked_questions.rst
@@ -104,6 +104,8 @@ get faster resolution by supporting a few best practices:
   slow down response time and make finding relevant information harder thereby
   slowing down time to resolution.
 - Let us know if you've solved the issue yourself (and let us know what worked!)
+- MOST IMPORTANT: do not hesitate to contact us (help@olcf.ornl.gov); we will
+  work through the details with you.
 
 
 Additional Resources

--- a/accounts/frequently_asked_questions.rst
+++ b/accounts/frequently_asked_questions.rst
@@ -84,6 +84,28 @@ need to return the broken/expired RSA token to OLCF. Disposal and
 recycling information can be found in the vendor's `disposal
 statement <https://www.emc.com/collateral/legal/token-disposal-statement.pdf>`__.
 
+.. _getting-help:
+
+Getting Help
+==============
+
+When submitting a ticket to help@olcf.ornl.gov requesting help, you will likely
+get faster resolution by supporting a few best practices:
+
+- Where possible, provide helpful details that can help speed the process. For
+  example: Project ID, relevant directories, job scripts, jobIDs, modules at
+  compile/runtime, host name, etc.
+- When replying to a ticket, do not modify the subject line.
+- Do not piggyback unrelated questions on existing tickets. This leads to slower
+  response times and inflates ticket history.
+- Do not open multiple tickets on the same unresolved topic. Doing so can
+  fragment resources and slow down the time to resolution.
+- Please do not respond to previous tickets with new, unrelated issues. This can
+  slow down response time and make finding relevant information harder thereby
+  slowing down time to resolution.
+- Let us know if you've solved the issue yourself (and let us know what worked!)
+
+
 Additional Resources
 =======================
 

--- a/index.rst
+++ b/index.rst
@@ -11,7 +11,8 @@ efficiently use OLCF compute and storage resources.
 
 Have an idea to improve this documentation? See :doc:`contributing/index`.
 
-Have a question? We're here to help -- help\@olcf.ornl.gov.
+Have a question? Write to us at -- help\@olcf.ornl.gov -- and consider the
+guidelines for :ref:`getting-help`.
 
 Accounts
 ---------


### PR DESCRIPTION
closes #70.

One thing: clicking on the "Getting Help" link takes you to the right place, but since it is the last FAQ entry, it isn't at the top of the page (depending on your browser window size), and so it may not be immediately obvious where you have been taken. I couldn't think of a better place to put this short section, but open to suggestions.