### PR TITLE
Rhea memory flag

### DIFF
--- a/systems/rhea_user_guide.rst
+++ b/systems/rhea_user_guide.rst
@@ -632,51 +632,53 @@ Common Batch Options to Slurm
 
 The following table summarizes frequently-used options to Slurm:
 
-+----------------+-------------------------------+-----------------------------------------------------------+
-| Option         | Use                           | Description                                               |
-+================+===============================+===========================================================+
-| -A             | #SBATCH -A <account>          | Causes the job time to be charged to ``<account>``.       |
-|                |                               | The account string, e.g. ``pjt000`` is typically composed |
-|                |                               | of three letters followed by three digits and optionally  |
-|                |                               | followed by a subproject identifier. The utility          |
-|                |                               | ``showproj`` can be used to list your valid assigned      |
-|                |                               | project ID(s). This option is required by all jobs.       |
-+----------------+-------------------------------+-----------------------------------------------------------+
-| -N             | #SBATCH -N <value>            | Number of compute nodes to allocate.                      |
-|                |                               | Jobs cannot request partial nodes.                        |
-+----------------+-------------------------------+-----------------------------------------------------------+
-|                | #SBATCH -t <time>             | Maximum wall-clock time. ``<time>`` is in the             |
-|                |                               | format HH:MM:SS.                                          |
-+----------------+-------------------------------+-----------------------------------------------------------+
-|                | #SBATCH -p <partition_name>   | Allocates resources on specified partition.               |
-+----------------+-------------------------------+-----------------------------------------------------------+
-| -o             | #SBATCH -o <filename>         | Writes standard output to ``<name>`` instead of           |
-|                |                               | ``<job_script>.o$SLURM_JOB_UID``. ``$SLURM_JOB_UID``      |
-|                |                               | is an environment variable created by Slurm that          |
-|                |                               | contains the batch job identifier.                        |
-+----------------+-------------------------------+-----------------------------------------------------------+
-| -e             | #SBATCH -e <filename>         | Writes standard error to ``<name>`` instead               |
-|                |                               | of ``<job_script>.e$SLURM_JOB_UID``.                      |
-+----------------+-------------------------------+-----------------------------------------------------------+
-| --mail-type    | #SBATCH --mail-type=FAIL      | Sends email to the submitter when the job fails.          |
-+----------------+-------------------------------+-----------------------------------------------------------+
-|                | #SBATCH --mail-type=BEGIN     | Sends email to the submitter when the job begins.         |
-+----------------+-------------------------------+-----------------------------------------------------------+
-|                | #SBATCH --mail-type=END       | Sends email to the submitter when the job ends.           |
-+----------------+-------------------------------+-----------------------------------------------------------+
-| --mail-user    | #SBATCH --mail-user=<address> | Specifies email address to use for                        |
-|                |                               | ``--mail-type`` options.                                  |
-+----------------+-------------------------------+-----------------------------------------------------------+
-| -J             | #SBATCH -J <name>             | Sets the job name to ``<name>`` instead of the            |
-|                |                               | name of the job script.                                   |
-+----------------+-------------------------------+-----------------------------------------------------------+
-| --get-user-env | #SBATCH --get-user-env        | Exports all environment variables from the                |
-|                |                               | submitting shell into the batch job shell.                |
-|                |                               | Since the login nodes differ from the service             |
-|                |                               | nodes, using the ``–get-user-env`` option is              |
-|                |                               | **not recommended**. Users should create the              |
-|                |                               | needed environment within the batch job.                  |
-+----------------+-------------------------------+-----------------------------------------------------------+
++------------------+-----------------------------------+-----------------------------------------------------------+
+| Option           | Use                               | Description                                               |
++==================+===================================+===========================================================+
+| -A               | #SBATCH -A <account>              | Causes the job time to be charged to ``<account>``.       |
+|                  |                                   | The account string, e.g. ``pjt000`` is typically composed |
+|                  |                                   | of three letters followed by three digits and optionally  |
+|                  |                                   | followed by a subproject identifier. The utility          |
+|                  |                                   | ``showproj`` can be used to list your valid assigned      |
+|                  |                                   | project ID(s). This option is required by all jobs.       |
++------------------+-----------------------------------+-----------------------------------------------------------+
+| -N               | #SBATCH -N <value>                | Number of compute nodes to allocate.                      |
+|                  |                                   | Jobs cannot request partial nodes.                        |
++------------------+-----------------------------------+-----------------------------------------------------------+
+|                  | #SBATCH -t <time>                 | Maximum wall-clock time. ``<time>`` is in the             |
+|                  |                                   | format HH:MM:SS.                                          |
++------------------+-----------------------------------+-----------------------------------------------------------+
+|                  | #SBATCH -p <partition_name>       | Allocates resources on specified partition.               |
++------------------+-----------------------------------+-----------------------------------------------------------+
+| -o               | #SBATCH -o <filename>             | Writes standard output to ``<name>`` instead of           |
+|                  |                                   | ``<job_script>.o$SLURM_JOB_UID``. ``$SLURM_JOB_UID``      |
+|                  |                                   | is an environment variable created by Slurm that          |
+|                  |                                   | contains the batch job identifier.                        |
++------------------+-----------------------------------+-----------------------------------------------------------+
+| -e               | #SBATCH -e <filename>             | Writes standard error to ``<name>`` instead               |
+|                  |                                   | of ``<job_script>.e$SLURM_JOB_UID``.                      |
++------------------+-----------------------------------+-----------------------------------------------------------+
+| \\-\\-mail-type  | #SBATCH \\-\\-mail-type=FAIL      | Sends email to the submitter when the job fails.          |
++------------------+-----------------------------------+-----------------------------------------------------------+
+|                  | #SBATCH \\-\\-mail-type=BEGIN     | Sends email to the submitter when the job begins.         |
++------------------+-----------------------------------+-----------------------------------------------------------+
+|                  | #SBATCH \\-\\-mail-type=END       | Sends email to the submitter when the job ends.           |
++------------------+-----------------------------------+-----------------------------------------------------------+
+| \\-\\-mail-user  | #SBATCH \\-\\-mail-user=<address> | Specifies email address to use for                        |
+|                  |                                   | ``--mail-type`` options.                                  |
++------------------+-----------------------------------+-----------------------------------------------------------+
+| -J               | #SBATCH -J <name>                 | Sets the job name to ``<name>`` instead of the            |
+|                  |                                   | name of the job script.                                   |
++------------------+-----------------------------------+-----------------------------------------------------------+
+|\\-\\-get-user-env| #SBATCH \\-\\-get-user-env        | Exports all environment variables from the                |
+|                  |                                   | submitting shell into the batch job shell.                |
+|                  |                                   | Since the login nodes differ from the service             |
+|                  |                                   | nodes, using the ``–get-user-env`` option is              |
+|                  |                                   | **not recommended**. Users should create the              |
+|                  |                                   | needed environment within the batch job.                  |
++------------------+-----------------------------------+-----------------------------------------------------------+
+| \\-\\-mem=0      | #SBATCH \\-\\-mem=0               | Declare to use all the available memory of the node       |
++------------------+-----------------------------------+-----------------------------------------------------------+
 
 
 .. note::


### PR DESCRIPTION
Add the flag to declare how to allocate all the memory on Rhea node. Moreover the double dashes "--" where not appeared correct, we need to use \\-\\-. This also closes #113