### PR TITLE
Jinja Templated RST

### DIFF
--- a/accounts/olcf_policy_guide.rst
+++ b/accounts/olcf_policy_guide.rst
@@ -223,23 +223,7 @@ categories: those intended for user data and those intended for project
 data. Within each of the two categories, we provide different sub-areas,
 each with an intended purpose:
 
-+----------------------------------------------------------------------------------------------------+---------------------+----------------------------+
-| Purpose                                                                                            | Storage Area        | Path                       |
-+====================================================================================================+=====================+============================+
-| Long-term data for routine access that is unrelated to a project                                   | *User Home*         | ``$HOME``                  |
-+----------------------------------------------------------------------------------------------------+---------------------+----------------------------+
-| Long-term data for archival access that is unrelated to a project                                  | *User Archive*      | ``/home/$USER``            |
-+----------------------------------------------------------------------------------------------------+---------------------+----------------------------+
-| Long-term project data for routine access that's shared with other project members                 | *Project Home*      | ``/ccs/proj/[projid]``     |
-+----------------------------------------------------------------------------------------------------+---------------------+----------------------------+
-| Short-term project data for fast, batch-job access that you don't want to share                    | *Member Work*       | ``$MEMBERWORK/[projid]``   |
-+----------------------------------------------------------------------------------------------------+---------------------+----------------------------+
-| Short-term project data for fast, batch-job access that's shared with other project members        | *Project Work*      | ``$PROJWORK/[projid]``     |
-+----------------------------------------------------------------------------------------------------+---------------------+----------------------------+
-| Short-term project data for fast, batch-job access that's shared with those outside your project   | *World Work*        | ``$WORLDWORK/[projid]``    |
-+----------------------------------------------------------------------------------------------------+---------------------+----------------------------+
-| Long-term project data for archival access that's shared with other project members                | *Project Archive*   | ``/proj/[projid]``         |
-+----------------------------------------------------------------------------------------------------+---------------------+----------------------------+
+{{ mk_tbl(Filesystems, "purpose", "area", "path") }}
 
 User Home
 ^^^^^^^^^
@@ -358,29 +342,11 @@ available at the OLCF.
 
 **User-Centric Storage Areas**
 
-+--------------+-----------------+------+-----------------+------------+---------+--------+-----------+
-| Area         | Path            | Type | Permissions     |  Quota     | Backups | Purged | Retention |
-+==============+=================+======+=================+============+=========+========+===========+
-| User Home    | ``$HOME``       | NFS  | User-controlled |  50 GB     | Yes     | No     | 90 days   |
-+--------------+-----------------+------+-----------------+------------+---------+--------+-----------+
-| User Archive | ``/home/user``  | HPSS | User-controlled |  2TB [#f1]_| No      | No     | 90 days   |
-+--------------+-----------------+------+-----------------+------------+---------+--------+-----------+
+{{ mk_tbl(UserFilesystems, "area", "path", "type", "permissions", "quota", "backups", "purged", "retention") }}
 
 **Project-Centric Storage Areas**
 
-+-----------------+---------------------------+--------+-----------------+---------------+---------+---------+-----------+
-| Area            | Path                      | Type   | Permissions     |  Quota        | Backups | Purged  | Retention |
-+=================+===========================+========+=================+===============+=========+=========+===========+
-| Project Home    | ``/ccs/proj/[projid]``    | NFS    | 770             |  50 GB        | Yes     | No      | 90 days   |
-+-----------------+---------------------------+--------+-----------------+---------------+---------+---------+-----------+
-| Member Work     | ``$MEMBERWORK/[projid]``  | Lustre | 700 [#f2]_      |  10TB         | No      | 14 days | [#f4]_    |
-+-----------------+---------------------------+--------+-----------------+---------------+---------+---------+-----------+
-| Project Work    | ``$PROJWORK/projid]``     | Lustre | 770             |  100TB        | No      | 90 days | [#f4]_    |
-+-----------------+---------------------------+--------+-----------------+---------------+---------+---------+-----------+
-| World Work      | ``$WORLDWORK/[projid]``   | Lustre | 775             |  10TB         | No      | 90 days | [#f4]_    |
-+-----------------+---------------------------+--------+-----------------+---------------+---------+---------+-----------+
-| Project Archive | ``/proj/[projid]``        | HPSS   | 770             |  100TB [#f3]_ | No      | No      | 90 days   |
-+-----------------+---------------------------+--------+-----------------+---------------+---------+---------+-----------+
+{{ mk_tbl(ProjFilesystems, "area", "path", "type", "permissions", "quota", "backups", "purged", "retention") }}
 
 | *Area -* The general name of storage area.
 | *Path -* The path (symlink) to the storage area's directory.
@@ -395,15 +361,15 @@ available at the OLCF.
     Project Work, World Work) are *not* backed up and are *purged* on a
     regular basis according to the timeframes listed above.
 
-.. rubric:: Footnotes
+.. note::
 
-.. [#f1] In addition, there is a quota/limit of 2,000 files on this directory.
+    * The *User Archive* also has a quota/limit of 2,000 files.
 
-.. [#f2] Permissions on Member Work directories can be controlled to an extent by project members. By default, only the project member has any accesses, but accesses can be granted to other project members by setting group permissions accordingly on the Member Work directory. The parent directory of the Member Work directory prevents accesses by "UNIX-others" and cannot be changed (security measures).
+    * The *Project Archive* also has a quota/limit of 100,000 files.
 
-.. [#f3] In addition, there is a quota/limit of 100,000 files on this directory.
+    * Retention is marked NA where files will follow purge cycle.
 
-.. [#f4] Retention is not applicable as files will follow purge cycle.
+    * Permissions on Member Work directories can be controlled to an extent by project members. By default, only the project member has any accesses, but accesses can be granted to other project members by setting group permissions accordingly on the Member Work directory. The parent directory of the Member Work directory prevents accesses by "UNIX-others" and cannot be changed (security measures).
 
 Data Retention Overview
 ^^^^^^^^^^^^^^^^^^^^^^^

--- a/conf.py
+++ b/conf.py
@@ -104,7 +104,7 @@ class PatchedHTMLTranslator(HTMLTranslator):
         super().visit_reference(node)
 
 
-def mk_tbl(tbl, hdrs):
+def mk_tbl(tbl, *hdrs):
     ''' Create a text table from the dictionary.
 
         tbl  : {str:[str]} = a mapping of column headers to lists of entries
@@ -128,13 +128,17 @@ def mk_tbl(tbl, hdrs):
 
 import yaml
 
-with open("systems.yaml") as f:
+with open("storage.yaml") as f:
     x = yaml.load(f, Loader=yaml.FullLoader)
     attrs = x[0].keys()
     Filesystems = dict((h, [y[h] for y in x]) for h in attrs)
+    UserFilesystems = dict((h, [y[h] for y in x if "User" in y['area']]) for h in attrs)
+    ProjFilesystems = dict((h, [y[h] for y in x if "User" not in y['area']]) for h in attrs)
 
 rst_context = {
         'Filesystems': Filesystems,
+        'UserFilesystems': UserFilesystems,
+        'ProjFilesystems': ProjFilesystems,
         'mk_tbl': mk_tbl,
         }
 def rstjinja(app, docname, source):

--- a/data/index.rst
+++ b/data/index.rst
@@ -14,10 +14,12 @@ Data Storage and Transfers
    transferring
    archiving
 
-**********************************
-Burst Buffer and Spectral Library
-**********************************
+.. seealso::
 
-Summit has node-local NVMe devices that can be used as :ref:`burst-buffer` by
-jobs, and the :ref:`spectral-library` can help with some of these use cases.
+   :ref:`burst-buffer`
+         Documentation for using Summit's node-local storage
+         to achieve short segments of high I/O bandwidth.
+
+   :ref:`spectral-library`
+         I/O library for using the burst buffer effectively.
 

--- a/data/policies.rst
+++ b/data/policies.rst
@@ -9,32 +9,16 @@ Policy
 A brief description of each area and basic guidelines to follow are provided in
 the table below:
 
-+-------------------+---------------------------------------------+---------------------------+-------------+---------+---------+-------+--------------------------+
-| *Name*            |   Path                                      |     Type                  | Permissions | Backups |  Purged | Quota | Mounted on Compute nodes |
-+===================+=============================================+===========================+=============+=========+=========+=======+==========================+
-| *User Home*       |   ``$HOME``                                 |     NFS                   |   User Set  |    yes  |    no   | 50GB  |   Read-only              |
-+-------------------+---------------------------------------------+---------------------------+-------------+---------+---------+-------+--------------------------+
-| *Project Home*    | ``/ccs/proj/[projid]``                      |     NFS                   |      770    |    yes  |    no   |  50GB |  Read-only               |
-+-------------------+---------------------------------------------+---------------------------+-------------+---------+---------+-------+--------------------------+
-| *User Archive*    | ``/home/$USER``                             |     HPSS                  |   User Set  |    no   |    no   |  2TB  |    No                    |
-+-------------------+---------------------------------------------+---------------------------+-------------+---------+---------+-------+--------------------------+
-| *Project Archive* | ``/proj/[projid]``                          |     HPSS                  |      770    |    no   |    no   | 100TB |     No                   |
-+-------------------+---------------------------------------------+---------------------------+-------------+---------+---------+-------+--------------------------+
-| *Member Work*     | ``/gpfs/alpine/scratch/[userid]/[projid]/`` | Spectrum Scale (ex. GPFS) |      700    |    no   | 90 days |  50TB |  Yes                     |
-+-------------------+---------------------------------------------+---------------------------+-------------+---------+---------+-------+--------------------------+
-| *Project Work*    | ``/gpfs/alpine/proj-shared/[projid]``       | Spectrum Scale (ex. GPFS) |      770    |    no   | 90 days |  50TB |  Yes                     |
-+-------------------+---------------------------------------------+---------------------------+-------------+---------+---------+-------+--------------------------+
-| *World Work*      | ``/gpfs/alpine/world-shared/[projid]``      | Spectrum Scale (ex. GPFS) |      775    |    no   | 90 days |  50TB |  Yes                     |
-+-------------------+---------------------------------------------+---------------------------+-------------+---------+---------+-------+--------------------------+
+{{ mk_tbl(Filesystems, "area", "path", "type", "permissions", "backups", "purged", "quota", "compute node access") }}
 
 
 On Summit paths to the various project-centric work storage areas are simplified
 by the use of environment variables that point to the proper directory on a
 per-user basis:
 
-- Member Work Directory:  ``$MEMBERWORK/[projid]``
-- Project Work Directory: ``$PROJWORK/[projid]``
-- World Work Directory: ``$WORLDWORK/[projid]``
+- Member Work Directory:  ``$MEMBERWORK = /gpfs/alpine/scratch/[userid]``
+- Project Work Directory: ``$PROJWORK = /gpfs/alpine/proj-shared``
+- World Work Directory: ``$WORLDWORK = /gpfs/alpine/world-shared``
 
 Information
 ============

--- a/data/user_centric.rst
+++ b/data/user_centric.rst
@@ -9,17 +9,11 @@ resources and lists relevant polices.
 
 **User-Centric Storage Areas**
 
-+--------------+-----------------+------+-----------------+-------------+---------+--------+-----------+
-| Area         | Path            | Type | Permissions     | Quota       | Backups | Purged | Retention |
-+==============+=================+======+=================+=============+=========+========+===========+
-| User Home    | ``$HOME``       | NFS  | User-controlled | 50 GB       | Yes     | No     | 90 days   |
-+--------------+-----------------+------+-----------------+-------------+---------+--------+-----------+
-| User Archive | ``/home/$USER`` | HPSS | User-controlled | 2 TB [#f1]_ | **No**  | No     | 90 days   |
-+--------------+-----------------+------+-----------------+-------------+---------+--------+-----------+
+{{ mk_tbl(UserFilesystems, "area", "path", "type", "permissions", "quota", "backups", "purged", "retention") }}
 
-.. rubric:: footnotes
+.. note::
 
-.. [#f1] In addition, there is a quota/limit of 2,000 files on this directory.
+    * The *User Archive* also has a quota/limit of 2,000 files.
 
 
 .. _user-home-directories-nfs:

--- a/storage.yaml
+++ b/storage.yaml
@@ -1,70 +1,77 @@
-  - area: "User Home"
+  - area: "*User Home*"
     purpose: "Long-term data for routine access that is unrelated to a project"
-    path: "$HOME"
+    path: "``$HOME``"
     permissions: "User-controlled"
     type: NFS
-    backups: Yes
-    purged: No
+    backups: "Yes"
+    purged: "No"
     quota: "50 GB"
     retention: "90 days"
+    compute node access: "Read-only"
 
-  - area: "User Archive"
+  - area: "*User Archive*"
     purpose: "Long-term data for archival access that is unrelated to a project"
-    path: "/home/$USER"
+    path: "``/home/$USER``"
     permissions: "User-controlled"
     type: HPSS
-    backups: No
-    purged: No
+    backups: "No"
+    purged: "No"
     quota: "2 TB"
     retention: "90 days"
+    compute node access: "No"
 
-  - area: "Project Home"
+  - area: "*Project Home*"
     purpose: "Long-term project data for routine access that’s shared with other project members"
-    path: "/ccs/proj/[projid]"
+    path: "``/ccs/proj/[projid]``"
     permissions: "770"
     type: NFS
-    backups: Yes
-    purged: No
+    backups: "Yes"
+    purged: "No"
     quota: "50 GB"
     retention: "90 days"
+    compute node access: "Read-only"
 
-  - area: "Member Work"
+  - area: "*Member Work*"
     purpose: "Short-term project data for fast, batch-job access that you don’t want to share"
-    path: "$MEMBERWORK/[projid]"
+    path: "``$MEMBERWORK/[projid]``"
     permissions: "700"
     type: Spectrum Scale
-    backups: No
+    backups: "No"
     purged: "90 days"
     quota: "50 TB"
     retention: "NA"
+    compute node access: "Yes"
 
-  - area: "Project Work"
+  - area: "*Project Work*"
     purpose: "Short-term project data for fast, batch-job access that’s shared with other project members"
-    path: "$PROJWORK/[projid]"
+    path: "``$PROJWORK/[projid]``"
     permissions: "770"
     type: Spectrum Scale
-    backups: No
+    backups: "No"
     purged: "90 days"
     quota: "50 TB"
     retention: "NA"
+    compute node access: "Yes"
 
-  - area: "World Work"
+  - area: "*World Work*"
     purpose: "Short-term project data for fast, batch-job access that’s shared with those outside your project"
-    path: "$WORLDWORK/[projid]"
+    path: "``$WORLDWORK/[projid]``"
     permissions: "775"
     type: Spectrum Scale
-    backups: No
+    backups: "No"
     purged: "90 days"
     quota: "50 TB"
     retention: "NA"
+    compute node access: "Yes"
 
-  - area: "Project Archive"
+  - area: "*Project Archive*"
     purpose: "Long-term project data for archival access that’s shared with other project members"
-    path: "/proj/[projid]"
+    path: "``/proj/[projid]``"
     permissions: "770"
     type: HPSS
-    backups: No
-    purged: No
+    backups: "No"
+    purged: "No"
     quota: "100 TB"
     retention: "90 days"
+    compute node access: "No"
 

--- a/systems.yaml
+++ b/systems.yaml
@@ -1,0 +1,70 @@
+  - area: "User Home"
+    purpose: "Long-term data for routine access that is unrelated to a project"
+    path: "$HOME"
+    permissions: "User-controlled"
+    type: NFS
+    backups: Yes
+    purged: No
+    quota: "50 GB"
+    retention: "90 days"
+
+  - area: "User Archive"
+    purpose: "Long-term data for archival access that is unrelated to a project"
+    path: "/home/$USER"
+    permissions: "User-controlled"
+    type: HPSS
+    backups: No
+    purged: No
+    quota: "2 TB"
+    retention: "90 days"
+
+  - area: "Project Home"
+    purpose: "Long-term project data for routine access that’s shared with other project members"
+    path: "/ccs/proj/[projid]"
+    permissions: "770"
+    type: NFS
+    backups: Yes
+    purged: No
+    quota: "50 GB"
+    retention: "90 days"
+
+  - area: "Member Work"
+    purpose: "Short-term project data for fast, batch-job access that you don’t want to share"
+    path: "$MEMBERWORK/[projid]"
+    permissions: "700"
+    type: Spectrum Scale
+    backups: No
+    purged: "90 days"
+    quota: "50 TB"
+    retention: "NA"
+
+  - area: "Project Work"
+    purpose: "Short-term project data for fast, batch-job access that’s shared with other project members"
+    path: "$PROJWORK/[projid]"
+    permissions: "770"
+    type: Spectrum Scale
+    backups: No
+    purged: "90 days"
+    quota: "50 TB"
+    retention: "NA"
+
+  - area: "World Work"
+    purpose: "Short-term project data for fast, batch-job access that’s shared with those outside your project"
+    path: "$WORLDWORK/[projid]"
+    permissions: "775"
+    type: Spectrum Scale
+    backups: No
+    purged: "90 days"
+    quota: "50 TB"
+    retention: "NA"
+
+  - area: "Project Archive"
+    purpose: "Long-term project data for archival access that’s shared with other project members"
+    path: "/proj/[projid]"
+    permissions: "770"
+    type: HPSS
+    backups: No
+    purged: No
+    quota: "100 TB"
+    retention: "90 days"
+


### PR DESCRIPTION
This PR adds jinja template processing to allow inserting code sections into rst files within ``{{ }}`` quotes.  The immediate application is to auto-generate most of the tables with filesystem properties in the documentation -- so all their information can be updated in one single (yaml) data source.

It also requires the yaml package for python.  Sphinx already uses jinja, so there is no extra jinja dependency.