### PR TITLE
Nicedcv to slurm

### DIFF
--- a/systems/rhea_user_guide.rst
+++ b/systems/rhea_user_guide.rst
@@ -1619,7 +1619,7 @@ Launch an interactive job:
 
 .. code::
 
-     salloc -A PROJECT_ID -p gpu -N 1 -t 60:00 -M rhea -C DCV bash
+     salloc -A PROJECT_ID -p gpu -N 1 -t 60:00 -M rhea -C DCV
 
 Run the following commands:
 

--- a/systems/rhea_user_guide.rst
+++ b/systems/rhea_user_guide.rst
@@ -1619,12 +1619,7 @@ Launch an interactive job:
 
 .. code::
 
-     qsub -I -A projectID   -l nodes=1 -l walltime=00:30:00 -l partition=gpu
-
-As of April 29, the dcv feature will be required:
-.. code::
-
-     qsub -I -A projectID   -l nodes=1 -l walltime=00:30:00 -l partition=gpu -l feature=dcv
+     salloc -A PROJECT_ID -p gpu -N 1 -t 60:00 -M rhea -C DCV bash
 
 Run the following commands:
 


### PR DESCRIPTION
Removed the step showing how to get an interactive job with Torque/Moab and replaced it with the salloc equivalent.