### PR TITLE
Removes extra `documentation` on page titles

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -54,6 +54,9 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 #
 html_theme = 'sphinx_rtd_theme'
 
+# The "title" is used in the HTML <title> tag of individual pages.
+html_title = 'OLCF User Documentation'
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".


### PR DESCRIPTION
As described in #109, the default Sphinx behavior for naming pages isn't very clean (at least in our existing structure).

This PR uses [html_title](http://www.sphinx-doc.org/en/master/usage/configuration.html#confval-html_title) to force all page titles to read `<Page Title> - OLCF User Documentation`.

This fixes #109.