### PR TITLE
Moves FAULT_TOLERANCE Issue to Resolved

### DIFF
--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -3125,7 +3125,7 @@ please see the `Vampir Software Page <https://www.olcf.ornl.gov/software_package
 Known Issues
 ============
 
-Last Updated: 09 September 2019
+Last Updated: 04 December 2019
 
 Open Issues
 -----------

--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -3130,14 +3130,6 @@ Last Updated: 09 September 2019
 Open Issues
 -----------
 
-JSM Fault Tolerance causes jobs to fail to start
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Adding ``FAULT_TOLERANCE=1`` in your individual ``~/.jsm.conf`` file,
-will result in LSF jobs failing to successfully start. A bug has been
-filed with IBM to address this issue.
-
-
 Spindle is not currently supported
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -3312,6 +3304,13 @@ following option to your jsrun command line:
 
 Resolved Issues
 ---------------
+
+JSM Fault Tolerance causes jobs to fail to start
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Adding ``FAULT_TOLERANCE=1`` in your individual ``~/.jsm.conf`` file,
+will result in LSF jobs failing to successfully start.
+
 
 The following issues were resolved with the July 16, 2019 software upgrade:
 

--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -3197,11 +3197,11 @@ Some users have reported seeing their jobs transition from the normal
 queued state, into a running state, and then back again to queued.
 Sometimes this can happen multiple times. Eventually, internal limits in
 the LSF scheduler will be reached, at which point the job will no longer
-be eligible for running. The bhist command can be used to see if a job
+be eligible for running. The ``bhist`` command can be used to see if a job
 is cycling between running and eligible states. The pending reason given
-by bhist can also be useful to debug. This can happen due to
+by ``bhist`` can also be useful to debug. This can happen due to
 modifications that the user has made to their environment on the system,
-incorrect ssh key setup, attempting to load unavailable/broken modules.
+incorrect SSH key setup, attempting to load unavailable/broken modules.
 or system problems with individual nodes. When jobs are observed to
 flip-flop between running and queued, and/or become ineligible without
 explanation, then deeper investigation is required and the user should
@@ -3210,11 +3210,11 @@ write to help@olcf.ornl.gov.
 jsrun explicit resource file (ERF) output format error
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-jsrun's option to create an explicit resource file (--erf\_output) will
+jsrun's option to create an explicit resource file (``--erf_output``) will
 incorrectly create a file with one line per rank. When reading the file
-in with (--erf\_input) you will see warnings for overlapping resource
-sets. This issue has been reported. The work around is to manually
-update the created erf file to contain a single line per resource set
+in with (``--erf_input``) you will see warnings for overlapping resource
+sets. This issue has been reported. The workaround is to manually
+update the created ERF file to contain a single line per resource set
 with multiple ranks per line.
 
 jsrun explicit resource file (ERF) allocates incorrect resources
@@ -3267,9 +3267,9 @@ jsrun's latency priority (``-l``) flag can be given lowercase values
 
 **Recommendation**:
 
-    It is currently recommended to only use the lowercase values to (-l /
-    --latency\_priority). The system default is: gpu-cpu,cpu-mem,cpu-cpu.
-    Since this ordering is used implicitly when the -l flag is omitted, this
+    It is currently recommended to only use the lowercase values to (``-l`` /
+    ``--latency_priority``). The system default is: gpu-cpu,cpu-mem,cpu-cpu.
+    Since this ordering is used implicitly when the ``-l`` flag is omitted, this
     issue only impacts submissions which explicitly include a latency
     priority in the jsrun command.
 


### PR DESCRIPTION
This is a partial review of Summit's Known Issues section.

The main change here is a move of the `FAULT_TOLERANCE` issue to resolved. Previously, setting `FAULT_TOLERANCE=1` in `~/.jsm.conf` would cause job launch to fail. This is reported fixed by IBM, and I have confirmed with a small job that launch works when this is set in the current software stack.