### PR TITLE
known issue that caused XL ICE when using -g flag moved to resolved

### DIFF
--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -3208,13 +3208,6 @@ been reported to IBM and they are investigating. It is generally
 recommended to use jsrun explicit resource files (ERF) with
 ``--erf_input`` and ``--erf_output`` instead of ``-U``.
 
--g flag causes internal compiler error with XL compiler
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Some users have reported an internal compiler error when compiling their
-code with XL with the \`-g\` flag. This has been reported to IBM and
-they are investigating.
-
 Jobs suspended due to retry limit / Queued job flip-flops between queued/running states
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
@@ -3356,6 +3349,16 @@ significant more amount of memory.
 
 The following issues were resolved
 with the May 21, 2019 upgrade:
+
+-g flag causes internal compiler error with XL compiler (Resolved: May 21, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some users have reported an internal compiler error when compiling their
+code with XL with the \`-g\` flag. This has been reported to IBM and
+they are investigating.
+
+.. note::
+		This bug was fixed in xl/16.1.1-3
 
 Issue with CUDA Aware MPI with >1 resource set per node (Resolved: May 21, 2019)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This PR moves the known issue titled "-g flag causes internal compiler error with XL compiler" into the resolved heading.