### PR TITLE
Specify master_doc to avoid issues with older versions

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -46,6 +46,10 @@ templates_path = ['_templates']
 # This pattern also affects html_static_path and html_extra_path.
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
+# To avoid errors with older versions of Sphinx and Sphinx RTD theme, explicitly
+# specify the master document.
+master_doc = 'index'
+
 
 # -- Options for HTML output -------------------------------------------------
 


### PR DESCRIPTION
On a system I was using where I was using sphinx and sphinx-rtd-theme from Ubuntu rather than from pip, my version of sphinx-build was old enough (1.6.7) that the RTD theme didn't work without specifying `master_doc`. I found the solution on SO:

https://stackoverflow.com/questions/56336234/build-fail-sphinx-error-contents-rst-not-found

which is consistent with the Sphinx documentation:

https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-master_doc

I tested this on both my older install that required it, and a newer one that didn't, and it works for both cases.