### PR TITLE
added training archive to docs

### DIFF
--- a/training/index.rst
+++ b/training/index.rst
@@ -4,6 +4,10 @@
 Training
 #########
 
+.. toctree::
+   :maxdepth: 2
+
+   training_archive
 
 * `Tutorials <https://github.com/olcf-tutorials>`_
 * `Archive <https://www.olcf.ornl.gov/for-users/training/training-archive/>`_

--- a/training/training_archive.rst
+++ b/training/training_archive.rst
@@ -1,0 +1,131 @@
+****************
+Training Archive
+****************
+
+In the sections below, you will find links to the slides and recordings of presentations given at previous OLCF training events. See the "Past Training Events" section of the `OLCF Training Calendar <https://www.olcf.ornl.gov/for-users/training/training-calendar/>`__ for the sources of these materials and the "Upcoming Training Events" section for future events.
+
+Batch Schedulers & Job Launchers
+================================
+
+* Summit Resource Scheduler and Job Launcher: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/02/STW_Feb_Summit-Job-Launch-Intro-Feb11-2019.pdf>`__ | `recording <https://vimeo.com/346452041>`__)
+* Intro to Slurm - Rhea: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/08/OLCF-Slurm-Transition-08282019.pdf>`__ | `recording <https://vimeo.com/360822772>`__)
+
+Debugging & Profiling
+=====================
+
+* Arm Forge Tools - DDT and MAP: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/09/Arm_Workshop.pdf>`__ | recordings `part 1 <https://vimeo.com/292364328>`__, `part 2 <https://vimeo.com/292365233>`__, `part 3 <https://vimeo.com/292365571>`__)
+* Profiling Tools Introduction: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/08/2_profiling_introduction.pdf>`__)
+* Intro to Tau: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/08/3_tau_day_1.pdf>`__)
+* Intro to Score-P: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/08/ScorepIntro.pdf>`__)
+* Intro to Scalasca: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/08/5_scalasca_day_1.pdf>`__)
+* Intro to Extrae/Paraver: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/08/extrae_day_1.pdf>`__)
+* NVIDIA Profilers: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_Profilers.pdf>`__ | `recording <https://vimeo.com/306437439>`__)
+* Introduction to NVIDIA Profilers on Summit: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/04/Intro_to_NVIDIA_profilers.pdf>`__)
+
+File Systems & Data Transfers
+=============================
+
+* Storage Areas & Data Transfers: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/storage_areas_summit_links.pdf>`__ | `recording <https://vimeo.com/306433952>`__)
+* Spectrum Scale - GPFS: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/spectrum_scale_summit_workshop.pdf>`__ | `recording <https://vimeo.com/306890694>`__)
+* NVMe / Burst Buffers: (slides `part 1 <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_BB_markomanolis.pdf>`__, `part 2 <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_BB_zimmer.pdf>`__ | recording `part 1 <https://vimeo.com/306890779>`__, `part 2 <https://vimeo.com/306891012>`__)
+
+Machine Learning / Deep Learning
+================================
+
+* ML/DL Frameworks on Summit: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_training_mldl.pdf>`__ | `recording <https://vimeo.com/307071617>`__)
+* Distributed Deep Learning on Summit: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/10/DDLonSummit.pdf>`__ | `recording <https://vimeo.com/377551223>`__)
+
+Networks
+========
+
+* SHARP & Adaptive Routing: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/05/Intro_Summit_Sharp-AR-Webinar.pdf>`__ | `recording <https://vimeo.com/277704649>`__)
+* Network Features & MPI Tuning: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_zimmer_network.pdf>`__ | `recording <https://vimeo.com/306891057>`__)
+
+OLCF Systems
+============
+
+* Summit System Overview: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/02/STW_Feb_Summit-Overview_20190211.pdf>`__ | `recording <https://vimeo.com/346452584>`__)
+* NVIDIA V100: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_Volta-Architecture.pdf>`__ | `recording <https://vimeo.com/306004462>`__)
+* IBM P9: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_thompto.pdf>`__ | `recording <https://vimeo.com/306003413>`__)
+* IBM P9 SMT Deep Dive: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_thompto_smt.pdf>`__ | `recording <https://vimeo.com/306890804>`__)
+
+Practical Tips
+==============
+
+* Practical Tips for Running on Summit: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/02/STW_Feb_GettingStartedExamples_169ratio.pdf>`__ | `recording <https://vimeo.com/346452176>`__)
+* OLCF Best Practices: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/06/Best-Practices-20190619.pdf>`__ | `recording <https://vimeo.com/343636411>`__)
+
+Programming
+===========
+
+Basic Programming
+-----------------
+
+* Intro to C: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/06/intro_to_c.pdf>`__ | `recording <https://vimeo.com/279284053>`__)
+* Intro to FORTRAN: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/06/Intro_to_HPC_fotranbasicsBM.pdf>`__ | `recording <https://vimeo.com/279286109>`__)
+
+Parallel Programming
+--------------------
+
+* Intro to Parallel Computing: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/06/Intro_to_HPC_parallel_computing.pdf>`__ | `recording <https://vimeo.com/279288481>`__)
+* Intro to OpenMP: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/06/intro_to_HPC_OpenMP.pdf>`__ | recording `part 1 <https://vimeo.com/279300607>`__, `part 2 <https://vimeo.com/279301009>`__)
+* Intro to MPI: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/06/intro_to_HPC_intro_to_mpi.pdf>`__ | `recording <https://vimeo.com/279313080>`__)
+
+GPU Programming
+---------------
+
+* Intro to GPU Computing: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/06/intro_to_HPC_gpu_computing.pdf>`__ | `recording <https://vimeo.com/279319729>`__)
+* Intro to CUDA: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/06/intro_to_HPC_cuda.pdf>`__ | `recording <https://vimeo.com/279313842>`__)
+* Intro to CUDA C/C++: (`slides <https://www.olcf.ornl.gov/calendar/introduction-to-cuda-cc/>`__)
+* Intro to OpenACC: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/06/IntroToOpenACC_Titan.pdf>`__ | `recording <https://vimeo.com/279329112>`__)
+* Programming Methods for Summit's Multi-GPU Nodes: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/11/multi-gpu-workshop.pdf>`__ | recording `part 1 <https://vimeo.com/308290719>`__, `part 2 <https://vimeo.com/308290811>`__)
+* Programming Methods for Targeting Summit's Multi-GPU Nodes: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/11/multi-gpu-workshop.pdf>`__)
+* Targeting Summit's Multi-GPU Nodes: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_MultiGPU-nodes.pdf>`__ | `recording <https://vimeo.com/306436688>`__)
+* CUDA Unified Memory: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/02/STF_Feb_UVM_feb.pdf>`__ | `recording <https://vimeo.com/346452488>`__)
+* GPU Direct, RDMA, CUDA-Aware MPI: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_CUDA-Aware-MPI.pdf>`__ | `recording <https://vimeo.com/306436248>`__)
+* GPU Accelerated Libraries: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_Libraries.pdf>`__ | `recording <https://vimeo.com/306437127>`__)
+* Using V100 Tensor Cores: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_Tensor-Cores.pdf>`__ | `recording <https://vimeo.com/306437682>`__)
+* Mixing OpenMP and OpenACC: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_mixingOpenMPOpenACC.pdf>`__ | `recording <https://vimeo.com/307071416>`__)
+* Intro to AMD GPU Programming with HIP: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/09/AMD_GPU_HIP_training_20190906.pdf>`__ | `recording <https://vimeo.com/359154970>`__)
+
+Programming Environment
+=======================
+
+* Summit Programming Environment: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/02/SMT_Feb_programming_environment.pdf>`__ | `recording <https://vimeo.com/346452383>`__)
+* Python on Summit: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/02/STW_Feb_20190211_summit_workshop_python.pdf>`__ | `recording <https://vimeo.com/346452419>`__)
+* Python Environments: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_20181206_python.pdf>`__ | `recording <https://vimeo.com/307070906>`__)
+
+Summit Porting Experiences
+==========================
+
+* CAAR Porting Experience - LS-DALTON: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/02/STW_Feb_LSDALTON.pdf>`__)
+* CAAR Porting Experience - RAPTOR: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/02/STW_Feb_RAPTOR.pdf>`__ | `recording <https://vimeo.com/346452450>`__)
+* CAAR Porting Experience - FLASH: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/02/STW_Feb_FLASH_Harris.pdf>`__ | `recording <https://vimeo.com/346452020>`__)
+* CAAR Porting Experience - QMCPACK: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_Tillack.pdf>`__ | `recording <https://vimeo.com/307071565>`__)
+* Directive-Based GPU Programming: (`recording <https://vimeo.com/306440151>`__)
+* E3SM Application Readiness Experiences on Summit: (`recording <http://vimeo.com/307071495>`__)
+* Experiences Using the Volta Tensor Cores on Summit: (`recording <http://vimeo.com/306890517>`__)
+* Experiences Porting/Optimizing Codes for Acceptance Testing: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_walkup.pdf>`__ | recording `part 1 <https://vimeo.com/306890861>`__, `part 2 <https://vimeo.com/306890949>`__)
+* Experiences Porting XGC to Summit: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_XGC_Ed.pdf>`__ | `recording <https://vimeo.com/307071032>`__)
+* Summit Node Performance: (`recording <http://vimeo.com/306890606>`__)
+* Targeting GPUs Using GPU Directives on Summit with GenASiS: A Simple and Effective Fortran Experience: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_budiardja.pdf>`__ | `recording <https://vimeo.com/306890448>`__)
+
+Text Editors
+============
+
+* Intro to vim: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/06/Intro_to_HPC_Vim.pdf>`__ | `recording <https://vimeo.com/279277260>`__)
+
+UNIX
+====
+
+* Intro to UNIX: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/07/Intro_to_Unix_2018.pdf>`__ | `recording <https://vimeo.com/279273125>`__)
+* Advanced UNIX & Shell Scripting: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/07/Intro_to_Unix_2018.pdf>`__ | `recording <https://vimeo.com/279313457>`__)
+* Linux Command Line Productivity Tools: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2019/12/LPT_OLCF.pdf>`__)
+
+Version Control
+===============
+
+* Intro to git: (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2018/06/Intro_to_HPC_Git.pdf>`__ | `recording <https://vimeo.com/279287047>`__)
+
+
+


### PR DESCRIPTION
This PR adds the Training Archive section to the new OLCF docs. It partially addresses #167 