### PR TITLE
Enable horizontal scrolling for tables at lower widths

### DIFF
--- a/_static/css/theme_overrides.css
+++ b/_static/css/theme_overrides.css
@@ -16,6 +16,6 @@
    }
 
    .wy-table-responsive {
-      overflow: visible !important;
+      overflow: auto !important;
    }
 }


### PR DESCRIPTION
Fixes #91.

This change enables horizontal scrolling for tables of class `.wy-table-responsive` when the content would otherwise not be visible (small widths that aren't small _enough_ to toggle mobile media queries).

Note that to pick up this change, for review and in production, one may need to clear their browser's cached styles.