### PR TITLE
Removes 'at the OLCF' from Software section title

### DIFF
--- a/software/index.rst
+++ b/software/index.rst
@@ -1,8 +1,8 @@
 .. _software-at-the-olcf:
 
-#####################
-Software at the OLCF
-#####################
+#########
+Software
+#########
 
 
 


### PR DESCRIPTION
Fixes #187