### PR TITLE
Adds link to Software News

### DIFF
--- a/software/index.rst
+++ b/software/index.rst
@@ -9,6 +9,7 @@ Software
 .. toctree::
    :maxdepth: 2
 
+   Software News <https://www.olcf.ornl.gov/for-users/software/software-news/>
    analytics/index
    python
    profiling/index


### PR DESCRIPTION
Resolves #223. Adds external link to software news on olcf main site. 

Will migrate content in a separate issue.