### PR TITLE
New versions of SW not Default SW

### DIFF
--- a/software/software-news.rst
+++ b/software/software-news.rst
@@ -27,7 +27,7 @@ versions have been deprecated.
 In addition, the following new packages have been installed and are available for use:
 
 .. csv-table::
-    :header: "Package", "Default Version"
+    :header: "Package", "New Version"
 
     "pgi", "20.1"
     "xl", "16.1.1-6"


### PR DESCRIPTION
The second table just shows new versions deployed, not new defaults. This fixes that header.