### PR TITLE
Add segfault on login node to known issues

### DIFF
--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -3126,10 +3126,18 @@ please see the `Vampir Software Page <https://www.olcf.ornl.gov/software_package
 Known Issues
 ============
 
-Last Updated: 01 February 2020
+Last Updated: 20 March 2020
 
 Open Issues
 -----------
+
+Segfault when running executables on login nodes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Executing a parallel binary on the login node or a batch node without using the job step launcher ``jsrun`` will result in a segfault. 
+
+This also can be encountered when importing parallel Python libraries like ``mpi4py`` and ``h5py`` directly on these nodes.
+
+The issue has been reported to IBM. The current workaround is to run the binary inside an interactive or batch job via ``jsrun``.
 
 Nsight Compute cannot be used with MPI programs
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
This was introduced with SMPI 10.3.1.2 and a bug has been opened with IBM.