### PR TITLE
Update Job Step Viewer limitations

### DIFF
--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -2894,7 +2894,6 @@ _____
 Limitations
 ___________
 
-* (currently) Only available on Summit
 * (currently) Compiled with GCC toolchain only
 * Does not support MPMD-mode via ERF
 * OpenMP only supported with use of the ``OMP_NUM_THREADS`` environment variable.


### PR DESCRIPTION
JSV now available on Ascent; removes Summit-only limitation.