### PR TITLE
Replaced link <https://www.olcf.ornl.gov/for-users/training/training-…

### DIFF
--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -14,7 +14,7 @@ documentation, instruction, and tutorials that could be useful for
 Summit users.
 
 The `OLCF Training
-Archive <https://www.olcf.ornl.gov/for-users/training/training-archive/>`__
+Archive <https://docs.olcf.ornl.gov/training/training_archive.html/>`__
 provides a list of previous training events, including multi-day Summit
 Workshops. Some examples of topics addressed during these workshops
 include using Summit's NVME burst buffers, CUDA-aware MPI, advanced

--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -13,9 +13,7 @@ In addition to this Summit User Guide, there are other sources of
 documentation, instruction, and tutorials that could be useful for
 Summit users.
 
-The `OLCF Training
-Archive <https://docs.olcf.ornl.gov/training/training_archive.html/>`__
-provides a list of previous training events, including multi-day Summit
+The :ref:`OLCF Training Archive<training-archive>` provides a list of previous training events, including multi-day Summit
 Workshops. Some examples of topics addressed during these workshops
 include using Summit's NVME burst buffers, CUDA-aware MPI, advanced
 networking and MPI, and multiple ways of programming multiple GPUs per

--- a/training/training_archive.rst
+++ b/training/training_archive.rst
@@ -1,3 +1,5 @@
+.. _training-archive:
+
 ****************
 Training Archive
 ****************


### PR DESCRIPTION
…archive/> with link <https://docs.olcf.ornl.gov/training/training_archive.html>.`