### PR TITLE
Adding Slate doc on integration with existing OLCF resources

### DIFF
--- a/services_and_applications/slate/access_olcf_resources/index.rst
+++ b/services_and_applications/slate/access_olcf_resources/index.rst
@@ -1,0 +1,20 @@
+#####################################
+Access OLCF Resources From Containers
+#####################################
+
+
+All containers run as the project-level automation user which has access to
+all project files. The automation username is always the project ID and
+appended with ``_auser``.
+
+.. note::
+  Most container images on registries like Docker Hub are built to run as root. This means 
+  that some images will need to be modified by changing ownership of writable directories
+  in the image.
+
+
+.. toctree::
+   :maxdepth: 2
+
+   job_submit
+   mount_fs

--- a/services_and_applications/slate/access_olcf_resources/job_submit.rst
+++ b/services_and_applications/slate/access_olcf_resources/job_submit.rst
@@ -1,0 +1,71 @@
+####################
+Batch Job Submission
+####################
+
+
+Batch job submission from containers is designed to work exactly like on a login
+node for the cluster. The workload will need to be annotated in order to get the
+necessary configuration injected at runtime.
+
+.. csv-table::
+  :header: "Cluster", "Annotation", "Value", "Schedulers"
+  :widths: 5, 10, 5, 5
+
+  "Marble", "ccs.ornl.gov/batchScheduler", "true", "Slurm, LSF"
+  "Onyx", "ccs.ornl.gov/batchScheduler", "true", "LSF"
+
+You can add the required annotations to any workload object such as a Pod, Deployment,
+or a DeploymentConfig. Submitting a batch job from a container requires access to
+the OLCF shared filesystems so that annotation is also included.
+
+.. code:: yaml
+
+  metadata:
+    annotations:
+      ccs.ornl.gov/batchScheduler: "true"
+      ccs.ornl.gov/fs: olcf
+
+
+Full example of a deployment using a base image provided by OLCF.
+
+.. note::
+  Batch job submission from containers uses SSH to access the submission host. If you
+  use your own image you must install the **openssh client** package in your image.
+
+.. code:: yaml
+
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: test-jobsubmit
+    annotations:
+      ccs.ornl.gov/batchScheduler: "true"
+      ccs.ornl.gov/fs: olcf
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: test-jobsubmit
+    template:
+        labels:
+          app: test-jobsubmit
+      spec:
+        containers:
+        - name: test-jobsubmit
+          image: "image-registry.openshift-image-registry.svc:5000/openshift/ccs-rhel7-base-amd64:latest"
+          args:
+          - cat
+          stdin: true
+          stdinOnce: true
+
+The annotation will install wrappers into /usr/bin:
+
+Slurm
+
+- sbatch
+- squeue
+
+LSF
+
+- bsub
+- bjobs

--- a/services_and_applications/slate/access_olcf_resources/mount_fs.rst
+++ b/services_and_applications/slate/access_olcf_resources/mount_fs.rst
@@ -1,0 +1,68 @@
+######################
+Mount OLCF Filesystems
+######################
+
+OLCF shared filesystems can be mounted into a container running in Slate. The mountpoints
+will be the same as a cluster node. The Kubernetes object will need to be annotated in order
+to get the necessary configuration injected into the container at runtime.
+
+.. csv-table::
+  :header: "Cluster", "Annotation", "Value", "Mounts"
+  :widths: 5, 8, 5, 25
+
+  "Marble", "ccs.ornl.gov/fs", "olcf", "/ccs/sw, /ccs/home, /ccs/proj, /gpfs/alpine"
+  "Onyx", "ccs.ornl.gov/fs", "ccsopen", "/ccsopen/sw, /ccsopen/home, /ccsopen/proj, /gpfs/wolf"
+
+If you already have a Deployment running you can add the annotation with the client
+
+.. code:: bash
+
+  oc annotate deployment web ccs.ornl.gov/fs=olcf
+
+.. warning::
+  You cannot annotate an existing pod because the injection happens at pod creation time
+
+  .. pull-quote::
+
+    Annotating a pod not managed by a deployment with ``oc annotate pod test ccs.ornl.gov/fs=olcf``
+    will not work. Instead delete the pod and add the annotation to the metadata and recreate it.
+
+You can also add the annotations to any workload object's YAML such as a Pod, Deployment,
+or DeploymentConfig.
+
+.. code:: yaml
+
+  metadata:
+    annotations:
+      ccs.ornl.gov/fs: olcf
+
+Full example of a deployment mounting the OLCF shared filesystems:
+
+.. code:: yaml
+
+  apiVersion: apps/v1
+  kind: Deployment
+  metadata:
+    name: test-fs
+    annotations:
+      ccs.ornl.gov/fs: olcf
+  spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: test-fs
+    template:
+        labels:
+          app: test-fs
+      spec:
+        containers:
+        - name: test-fs
+          image: busybox:latest
+          args:
+          - cat
+          stdin: true
+          stdinOnce: true
+
+.. note::
+  There are no requirements in the container image in order to mount OLCF filesystems
+

--- a/services_and_applications/slate/index.rst
+++ b/services_and_applications/slate/index.rst
@@ -8,5 +8,6 @@ Slate
 
    overview
    getting_started
+   access_olcf_resources/index.rst
    olcf_provided_applications/index.rst
    building_your_own_application/index.rst


### PR DESCRIPTION
Adds documentation about how to access OLCF resources from containers running in Slate