### PR TITLE
Updated wording about olcf defaults differing from man page values

### DIFF
--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -2617,8 +2617,9 @@ jsrun Format
 Common jsrun Options
 """"""""""""""""""""
 
-Below are common jsrun options. More flags and details can be found in
-the jsrun man page.
+Below are common jsrun options. More flags and details can be found in the jsrun
+man page. The defaults listed in the table below are the OLCF defaults and take
+precedence over those mentioned in the man page.
 
 
 +---------------------------+--------+------------------------------------------------------+------------------------------+
@@ -2646,9 +2647,9 @@ the jsrun man page.
 | ``--launch_distribution`` | ``-d`` | How tasks are started on resource sets               | packed                       |
 +---------------------------+--------+------------------------------------------------------+------------------------------+
 
-It's recommended to explicitly specify ``jsrun`` options. This most
-often includes ``--nrs``,\ ``--cpu_per_rs``, ``--gpu_per_rs``,
-``--tasks_per_rs``, ``--bind``, and ``--launch_distribution``.
+It's recommended to explicitly specify ``jsrun`` options and not rely on the
+default values. This most often includes ``--nrs``,\ ``--cpu_per_rs``,
+``--gpu_per_rs``, ``--tasks_per_rs``, ``--bind``, and ``--launch_distribution``.
 
 jsrun Examples
 ^^^^^^^^^^^^^^


### PR DESCRIPTION
This is important to emphasize in our docs because the man pages
for jsrun can list different defaults than what we set on the machines
and so users can get confused. Having a warning here would be useful.