### PR TITLE
Adding a link to our tutorials and examples page 

### DIFF
--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -13,11 +13,12 @@ In addition to this Summit User Guide, there are other sources of
 documentation, instruction, and tutorials that could be useful for
 Summit users.
 
-The :ref:`OLCF Training Archive<training-archive>` provides a list of previous training events, including multi-day Summit
-Workshops. Some examples of topics addressed during these workshops
-include using Summit's NVME burst buffers, CUDA-aware MPI, advanced
-networking and MPI, and multiple ways of programming multiple GPUs per
-node.
+The :ref:`OLCF Training Archive<training-archive>` provides a list of previous training
+events, including multi-day Summit Workshops. Some examples of topics addressed during
+these workshops include using Summit's NVME burst buffers, CUDA-aware MPI, advanced
+networking and MPI, and multiple ways of programming multiple GPUs per node. You can also
+find simple tutorials and code examples for some common programming and running tasks in
+our `Github tutorial page <https://github.com/olcf-tutorials>`_ .
 
 .. _system-overview:
 


### PR DESCRIPTION
Adding a tutorial github link at top of the Summit doc.

This came after a suggestion from a new user who was overwhelmed from navigating the Summit doc and had found those github tutorials very helpful in providing context and practical examples. 