### PR TITLE
Correcting minor formatting errors on several pages

### DIFF
--- a/accounts/olcf_policy_guide.rst
+++ b/accounts/olcf_policy_guide.rst
@@ -2,8 +2,6 @@
 OLCF Policy Guides
 ****************************
 
-********
-
 OLCF Acknowledgement
 ====================
 
@@ -1154,4 +1152,3 @@ changes on the project.
 If you have security-related questions, contact us via email at: security-admins@ccs.ornl.gov.
 Other questions can be sent to help@olcf.ornl.gov.
 
-********

--- a/services_and_applications/slate/guided_tutorial_cli.rst
+++ b/services_and_applications/slate/guided_tutorial_cli.rst
@@ -1,8 +1,8 @@
 .. _slate_guided_tutorial_cli:
 
-***************
+********************
 Guided Tutorial: CLI
-***************
+********************
 
 This tutorial is a continuation of the :ref:`slate_guided_tutorial` and you should start there.
 

--- a/software/analytics/ibm-wml-ce.rst
+++ b/software/analytics/ibm-wml-ce.rst
@@ -73,7 +73,7 @@ Comparing to IBM WML CE, `Open-CE <https://github.com/open-ce/open-ce>`_ no long
     | ML/DL on Summit (`slides <https://www.olcf.ornl.gov/wp-content/uploads/2020/02/MLDL-on-Summit-June2020.pdf>`__ | `recording <https://vimeo.com/427791205>`__)
 
 Running Distributed Deep Learning Jobs
-================
+======================================
 
 The IBM ``ddlrun`` tool has been deprecated. The recommended tool for
 launching distributed deep learning jobs on Summit is ``jsrun``. When
@@ -99,7 +99,7 @@ correctly launch most DDL scripts:
 +----------------+------------------------------------------------------+
 
 Basic Distributed Deep Learning BSUB Script
----------------------
+-------------------------------------------
 
 The following bsub script will run a distributed Tensorflow resnet50
 training job across 2 nodes.

--- a/systems/andes_user_guide.rst
+++ b/systems/andes_user_guide.rst
@@ -1287,6 +1287,7 @@ methods may be used the one described should work in most cases.
      </Server>
      # ...
     </Servers>
+
 **Step 2: Launch ParaView on your Desktop and Click on File -> Connect**
 
 Start ParaView and then select ``File/Connect`` to begin.

--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -204,9 +204,9 @@ I/O.  More information can be found later in the `Burst Buffer`_ section.
 Software
 ========
 
-Visualization and analysis tasks should be done on the Rhea cluster. There are a
+Visualization and analysis tasks should be done on the Andes cluster. There are a
 few tools provided for various visualization tasks, as described in the
-:ref:`visualization-tools` section of the :ref:`rhea-user-guide`.
+:ref:`visualization-tools` section of the :ref:`andes-user-guide`.
 
 For a full list of software available at the OLCF, please see the
 Software section (coming soon).


### PR DESCRIPTION
The sphinx-build process was reporting minor formatting errors on a few files; additionally the Summit User Guide had a link to the Rhea User Guide. Corrected those errors & updated the link to reference the Andes guide.