### PR TITLE
Summit myolcf update

### DIFF
--- a/systems/andes_user_guide.rst
+++ b/systems/andes_user_guide.rst
@@ -1073,13 +1073,7 @@ allocated to multiple jobs. Because the OLCF charges based on what a job makes
 uses only one core on a node. To simplify the process, users are given a
 multiples of entire nodes through Slurm.
 
-Viewing Allocation Utilization
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Projects are allocated time on Andes in units of *node-hours*. This is separate
-from a project's Summit allocation, and usage of Andes does not count against
-that allocation. This page describes how such units are calculated, and how
-users can access more detailed information on their relevant allocations.
+Allocations on Andes are separate from those on Summit and other OLCF resources.
 
 Node-Hour Calculation
 ^^^^^^^^^^^^^^^^^^^^^
@@ -1113,7 +1107,7 @@ of run-time errors (e.g. the user's application causes a segmentation fault) are
 counted against the allocation.
 
 Each user may view usage for projects on which they are members from the command
-line tool ``showusage`` and the `My OLCF site <https://users.nccs.gov>`__.
+line tool ``showusage`` and the `myOLCF site <https://my.olcf.ornl.gov>`__.
 
 On the Command Line via ``showusage``
 """""""""""""""""""""""""""""""""""""
@@ -1132,11 +1126,11 @@ through midnight of the previous day. For example:
 
 The ``-h`` option will list more usage details.
 
-On the Web via My OLCF
+On the Web via myOLCF
 """"""""""""""""""""""
 
-More detailed metrics may be found on each project's usage section of the `My
-OLCF site <https://users.nccs.gov>`__. The following information is available
+More detailed metrics may be found on each project's usage section of the `myOLCF
+site <https://my.olcf.ornl.gov>`__. The following information is available
 for each project:
 
 -  YTD usage by system, subproject, and project member
@@ -1147,8 +1141,10 @@ for each project:
 -  Batch system priorities by project and subproject
 -  Project members
 
-The My OLCF site is provided to aid in the utilization and management of OLCF
-allocations. If you have any questions or have a request for additional data,
+The myOLCF site is provided to aid in the utilization and management of OLCF
+allocations. See the :doc:`myOLCF Documentation </services_and_applications/myolcf/index>` for more information. 
+
+If you have any questions or have a request for additional data,
 please contact the OLCF User Assistance Center.
 
 --------------

--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -2309,9 +2309,38 @@ compute node. This may be beneficial because it provides more resources
 for GPFS service tasks, but it may also cause resource contention for
 the jsrun compute job.
 
+Job Accounting on Summit
+------------------------
+
+Jobs on Summit are scheduled in full node increments; a node's cores cannot be
+allocated to multiple jobs. Because the OLCF charges based on what a job makes
+*unavailable* to other users, a job is charged for an entire node even if it
+uses only one core on a node. To simplify the process, users request and are allocated
+multiples of entire nodes through LSF.
+
+Allocations on Summit are separate from those on Andes and other OLCF resources.
+
+Node-Hour Calculation
+^^^^^^^^^^^^^^^^^^^^^
+
+The *node-hour* charge for each batch job will be calculated as follows:
+
+.. code::
+
+    node-hours = nodes requested * ( batch job endtime - batch job starttime )
+
+Where *batch job starttime* is the time the job moves into a running state, and
+*batch job endtime* is the time the job exits a running state.
+
+A batch job's usage is calculated solely on requested nodes and the batch job's
+start and end time. The number of cores actually used within any particular node
+within the batch job is not used in the calculation. For example, if a job
+requests (6) nodes through the batch script, runs for (1) hour, uses only (2)
+CPU cores per node, the job will still be charged for 6 nodes \* 1 hour = *6
+node-hours*.
 
 Viewing Usage
--------------
+^^^^^^^^^^^^^
 
 Utilization is calculated daily using batch jobs which complete between 00:00
 and 23:59 of the previous day. For example, if a job moves into a run state on
@@ -2323,10 +2352,10 @@ of run-time errors (e.g. the user's application causes a segmentation fault) are
 counted against the allocation.
 
 Each user may view usage for projects on which they are members from the command
-line tool ``showusage`` and the `My OLCF site <https://users.nccs.gov>`__.
+line tool ``showusage`` and the `myOLCF site <https://my.olcf.ornl.gov>`__.
 
 On the Command Line via ``showusage``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+"""""""""""""""""""""""""""""""""""""
 
 The ``showusage`` utility can be used to view your usage from January 01
 through midnight of the previous day. For example:
@@ -2342,11 +2371,11 @@ through midnight of the previous day. For example:
 
 The ``-h`` option will list more usage details.
 
-On the Web via My OLCF
-^^^^^^^^^^^^^^^^^^^^^^
+On the Web via myOLCF
+""""""""""""""""""""""
 
-More detailed metrics may be found on each project's usage section of the `My
-OLCF site <https://users.nccs.gov>`__. The following information is available
+More detailed metrics may be found on each project's usage section of the `myOLCF
+site <https://my.olcf.ornl.gov>`__. The following information is available
 for each project:
 
 -  YTD usage by system, subproject, and project member
@@ -2357,9 +2386,12 @@ for each project:
 -  Batch system priorities by project and subproject
 -  Project members
 
-The My OLCF site is provided to aid in the utilization and management of OLCF
-allocations. If you have any questions or have a request for additional data,
+The myOLCF site is provided to aid in the utilization and management of OLCF
+allocations. See the :doc:`myOLCF Documentation </services_and_applications/myolcf/index>` for more information.
+
+If you have any questions or have a request for additional data,
 please contact the OLCF User Assistance Center.
+
 
 
 Other Notes

--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -2309,30 +2309,58 @@ compute node. This may be beneficial because it provides more resources
 for GPFS service tasks, but it may also cause resource contention for
 the jsrun compute job.
 
-Resource Accounting
--------------------
 
-While logged into Summit, users can show their YTD usage and allocation
-by project using the ``showusage`` command. System specific details can
-be obtained with the ``-s`` flag. For example,
+Viewing Usage
+-------------
+
+Utilization is calculated daily using batch jobs which complete between 00:00
+and 23:59 of the previous day. For example, if a job moves into a run state on
+Tuesday and completes Wednesday, the job's utilization will be recorded
+Thursday. Only batch jobs which write an end record are used to calculate
+utilization. Batch jobs which do not write end records due to system failure or
+other reasons are not used when calculating utilization. Jobs which fail because
+of run-time errors (e.g. the user's application causes a segmentation fault) are
+counted against the allocation.
+
+Each user may view usage for projects on which they are members from the command
+line tool ``showusage`` and the `My OLCF site <https://users.nccs.gov>`__.
+
+On the Command Line via ``showusage``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``showusage`` utility can be used to view your usage from January 01
+through midnight of the previous day. For example:
 
 .. code::
 
-    $ showusage -s summit
+      $ showusage
+        Usage:
+                                 Project Totals
+        Project             Allocation      Usage      Remaining     Usage
+        _________________|______________|___________|____________|______________
+        abc123           |  20000       |   126.3   |  19873.7   |   1560.80
 
-    summit usage for the project's current allocation period:
-                                      Project Totals          [USERID]
-     Project      Allocation        Usage    Remaining          Usage
-    __________________________|____________________________|_____________
-     [PROJID1]        50000   |      15728        34272    |         65
-     [PROJID2]        20000   |       1234        18766    |          0
+The ``-h`` option will list more usage details.
 
-For additional details, please see the help message printed when using
-the ``-h`` flag:
+On the Web via My OLCF
+^^^^^^^^^^^^^^^^^^^^^^
 
-.. code::
+More detailed metrics may be found on each project's usage section of the `My
+OLCF site <https://users.nccs.gov>`__. The following information is available
+for each project:
 
-     $ showusage -h
+-  YTD usage by system, subproject, and project member
+-  Monthly usage by system, subproject, and project member
+-  YTD usage by job size groupings for each system, subproject, and
+   project member
+-  Weekly usage by job size groupings for each system, and subproject
+-  Batch system priorities by project and subproject
+-  Project members
+
+The My OLCF site is provided to aid in the utilization and management of OLCF
+allocations. If you have any questions or have a request for additional data,
+please contact the OLCF User Assistance Center.
+
 
 Other Notes
 -----------


### PR DESCRIPTION
Was adding a myOLCF link to the Summit page when I noticed the discussions of job accounting differed slightly between the Summit and Andes guides, and the Andes guide had an old link for myOLCF. Modified to make the two pages consistent, to link to the new myOLCF, and to update references form 'My OLCF' to the newer 'myOLCF' styling.