### PR TITLE
Software news about OpenCE 1.4.0 on Summit

### DIFF
--- a/software/software-news.rst
+++ b/software/software-news.rst
@@ -47,6 +47,8 @@ The following packages are available in this release of OpenCE:
     "OpenCV", "3.4.14"
     "Horovod", "0.22.1"
     
+.. raw:: html
+    
     Please note that DALI and Tensorflow Serving are currently unavailable on ppc64le. We are working with IBM to
     resolve the issue and will publish and update once available.
 


### PR DESCRIPTION
Currently DALI is not available so it is temporarily removed from this list. IBM is aware and investigating. 