### PR TITLE
restructuring multithreading information for Summit jobs

### DIFF
--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -1801,7 +1801,8 @@ environment variable to give you visual thread assignment information.
 In the below example, you could also do ``export OMP_NUM_THREADS=16`` in your
 job script instead of passing it as a ``-E`` flag to jsrun. The below example
 starts 1 resource set with 2 tasks and 8 cores, 4 cores bound to each task,
-16 threads for each task.
+16 threads for each task. We can set 16 threads since there are 4 cores
+per task and the default is smt4 for each core (4 * 4 = 16 threads).
 
 ::
    


### PR DESCRIPTION
I've added a section explaining the use of OMP_NUM_THREADS. I've reworked the docs a little so that the Job Launcher (jsrun) section is broken out into more pieces to give more visibility to the subsections that were usually hidden under Job Launcher (jsrun) and were hard to find.

You will want to pull my branch locally and build it with sphinx to see how it looks on the rendered webpage.