### PR TITLE
corrected MI250X count to 768 instead of 1536 (which is GCD count)

### DIFF
--- a/systems/crusher_quick_start_guide.rst
+++ b/systems/crusher_quick_start_guide.rst
@@ -66,7 +66,7 @@ Crusher is connected to the center-wide IBM Spectrum Scale™ filesystem providi
 GPUs
 ----
 
-Crusher contains a total of 1536 AMD MI250X. The AMD MI250X has a peak performance of 52 TFLOPS in double-precision for modeling and simulation. Each MI250X contains 2 GPUs, where each GPU has a peak performance of 26 TFLOPS (double-precision), 110 compute units, and 64 GB of high-bandwidth memory (HBM2) which can be accessed at a peak of 1.6 TB/s. The 2 GPUs on an MI250X are connected with Infinity Fabric with a bandwidth of 200 GB/s (in both directions simultaneously).
+Crusher contains a total of 768 AMD MI250X. The AMD MI250X has a peak performance of 52 TFLOPS in double-precision for modeling and simulation. Each MI250X contains 2 GPUs, where each GPU has a peak performance of 26 TFLOPS (double-precision), 110 compute units, and 64 GB of high-bandwidth memory (HBM2) which can be accessed at a peak of 1.6 TB/s. The 2 GPUs on an MI250X are connected with Infinity Fabric with a bandwidth of 200 GB/s (in both directions simultaneously).
 
 ----
 


### PR DESCRIPTION
The number of MI250X in Crusher was accidentally listed as 1536 (which is the number of GCDs not MI250X). This PR changes that number to be the correct value of 768.

192 compute nodes * (4 MI250X / compute node) = 768 MI250X
192 compute nodes * (4 MI250X / compute node) * (2 GCDs / MI250X) = 1536 GCDs