### PR TITLE
MPICH and ROCm compatibility on Crusher

### DIFF
--- a/systems/crusher_quick_start_guide.rst
+++ b/systems/crusher_quick_start_guide.rst
@@ -249,6 +249,11 @@ To use GPU-aware Cray MPICH, users must set the following modules and environmen
 
     export MPICH_GPU_SUPPORT_ENABLED=1
 
+Determining the Compatibility of Cray MPICH and ROCm
+""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Releases of ``cray-mpich`` are each built with a specific version of ROCm, and compatibility across multiple versions is not guaranteed. OLCF will maintain compatible default modules when possible. If using non-default modules, you can determine compatibility by reviewing the *Product and OS Dependencies* section in the ``cray-mpich`` release notes. This can displayed by running ``module show cray-mpich/<version>``. If the notes indicate compatibility with *AMD ROCM X.Y or later*, only use ``rocm/X.Y.Z`` modules. If using a non-default version of ``cray-mpich``, you must add ``${CRAY_MPICH_ROOTDIR}/gtl/lib`` to either your ``LD_LIBRARY_PATH`` at run time or your executable's rpath at build time.
+
 .. note::
 
     There are extra steps needed to enable GPU-aware MPI on Crusher, which depend on the compiler that is used (see 1. and 2. below).

--- a/systems/crusher_quick_start_guide.rst
+++ b/systems/crusher_quick_start_guide.rst
@@ -249,11 +249,6 @@ To use GPU-aware Cray MPICH, users must set the following modules and environmen
 
     export MPICH_GPU_SUPPORT_ENABLED=1
 
-Determining the Compatibility of Cray MPICH and ROCm
-""""""""""""""""""""""""""""""""""""""""""""""""""""
-
-Releases of ``cray-mpich`` are each built with a specific version of ROCm, and compatibility across multiple versions is not guaranteed. OLCF will maintain compatible default modules when possible. If using non-default modules, you can determine compatibility by reviewing the *Product and OS Dependencies* section in the ``cray-mpich`` release notes. This can displayed by running ``module show cray-mpich/<version>``. If the notes indicate compatibility with *AMD ROCM X.Y or later*, only use ``rocm/X.Y.Z`` modules. If using a non-default version of ``cray-mpich``, you must add ``${CRAY_MPICH_ROOTDIR}/gtl/lib`` to either your ``LD_LIBRARY_PATH`` at run time or your executable's rpath at build time.
-
 .. note::
 
     There are extra steps needed to enable GPU-aware MPI on Crusher, which depend on the compiler that is used (see 1. and 2. below).
@@ -290,6 +285,11 @@ To use GPU-aware Cray MPICH with ``hipcc``, users must include appropriate heade
     -L${MPICH_DIR}/lib -lmpi -L${CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa
 
     HIPFLAGS = --amdgpu-target=gfx90a
+
+Determining the Compatibility of Cray MPICH and ROCm
+""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Releases of ``cray-mpich`` are each built with a specific version of ROCm, and compatibility across multiple versions is not guaranteed. OLCF will maintain compatible default modules when possible. If using non-default modules, you can determine compatibility by reviewing the *Product and OS Dependencies* section in the ``cray-mpich`` release notes. This can be displayed by running ``module show cray-mpich/<version>``. If the notes indicate compatibility with *AMD ROCM X.Y or later*, only use ``rocm/X.Y.Z`` modules. If using a non-default version of ``cray-mpich``, you must add ``${CRAY_MPICH_ROOTDIR}/gtl/lib`` to either your ``LD_LIBRARY_PATH`` at run time or your executable's rpath at build time.
 
 OpenMP
 ------


### PR DESCRIPTION
Compatibility between cray-mpich and rocm is not guaranteed across multiple versions. This commit adds documentation to help the user determine a compatible pairing of cray-mpich and rocm.