### PR TITLE
Adding 'Differences between Summit and Crusher' Section

### DIFF
--- a/systems/crusher_quick_start_guide.rst
+++ b/systems/crusher_quick_start_guide.rst
@@ -1053,6 +1053,25 @@ And here is the output from the script:
 
 ----
 
+Notable Differences between Summit and Crusher
+============
+
+This section details 'tips and tricks' and information of interest to users when porting from Summit to Crusher.
+
+Using reduced precision (FP16, FP32, and BF16 datatypes)
+----------
+Users using BF16, FP16, and FP32 datatypes for applications such as ML/AI training and low-precision matrix multiplication should be aware that the AMD MI250X GPU has different denormal handling than the V100 GPUs on Summit. On the MI250X, the V_DOT2 and the matrix instructions for FP32, FP16, BF16, flush input and output denormal values to zero. FP64 MFMA instructions do not flush input and output denormal values to zero. 
+
+When training deep learning models using FP16 precision, some models may fail to converge with FP16 denorms flushed to zero. This occurs in operations encountering denormal values, and so is more likely to occur in FP16 because of a small dynamic range. BF16 and FP32 numbers have a larger dynamic range than FP16 numbers, and so are less likely to encounter denormal values.
+
+If you encounter significant differences when running using reduced precision, explore replacing non-converging models in FP16 with BF16, because of the greater dynamic range in BF16. We recommend using BF16 for ML models in general. If you have further questions or encounter issues, contact help@olcf.ornl.gov.
+
+Additional information on MI250X reduced precision can be found at:
+  * The MI250X ISA specification details the flush to zero denorm behavior at: https://developer.amd.com/wp-content/resources/CDNA2_Shader_ISA_18November2021.pdf (See page 41 and 46)
+  * AMD rocBLAS library reference guide details this behavior at: https://rocblas.readthedocs.io/en/master/API_Reference_Guide.html#mi200-gfx90a-considerations
+
+----
+
 Getting Help
 ============
 


### PR DESCRIPTION
Update to Crusher Quick Start guide. 

  * Adding a section that documents important differences between Summit and Crusher. 
  * To be populated with more information in the future.
  * Initially documenting differences in denorm, 'flush to zero' behavior on MI250X and V100.