### PR TITLE
Summit Guide: reorganized SPI Citadel mentions

### DIFF
--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -276,14 +276,6 @@ family is first present in the environment.
     modulefiles. However, long and logic-heavy Tcl modulefiles may require
     porting to Lua.
 
-.. note::
-    Because of the mismatched operating system versions between the Moderate Enhanced login node and the Summit
-    compute nodes, the ``module`` command is not available on the Moderate Enhanced login node. Similar to how
-    users need to compile on a batch node, the module system is also only available on the batch nodes. For
-    more information see :ref:`compiling-mod-enhanced` .
-    Eventually, the Summit login nodes will be upgraded to match the Moderate Enhanced login node and this
-    will no longer be necessary
-
 General Usage
 ^^^^^^^^^^^^^
 
@@ -436,38 +428,6 @@ using the modules system:
 
 
 
-.. _compiling-mod-enhanced:
-
-Compiling for Projects in the Moderate Enhanced Security Enclave 
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-
-Moderate Enhanced projects need to compile code on a batch node rather than the moderate-enhanced login node because the
-login node has a newer version of the operating system than standard Summit login nodes and compute nodes. 
-To do this requires submitting an interactive batch job and then compiling the code on the batch node. Additionally, users need
-to "relogin" on the batch node to setup the environment properly. The easiest way to do this is to add ``-l`` (dash "ell") to the $SHELL argument as
-shown below. To facilitate the requirement to compile on batch nodes, users can 
-submit to the ``debug-spi`` queue for a slight priority boost. Note that machine load on Summit can still delay
-startup of the interactive job unfortunately. Typical work flow would be:
-
-::
-   
-   user@citadel > bsub -q debug-spi -nnodes 1  -P ABC123_MDE -W 2:00 -Is $SHELL -l
-   Job <XXXXXX> is submitted to queue <debug-spi>
-   <<Waiting for dispatch ....>>
-   [Possible delay here until a node is available]
-   <<Starting on batchX>>
-   prompt > cd /path/to/the/code
-   prompt > cmake or ./configure or whatever is needed to configure and prepare the code for compiling
-   prompt > make  or whatever is needed to compile the code
-
-At this point, it is possible to run a quick test job using jsrun or fix any compilation issues which may have occured.
-
-
-.. note:: 
-
-    Eventually, the Summit compute nodes will be upgraded to match the Moderate Enhanced login node and this will no longer be necessary
-
-    
 C compilation
 ^^^^^^^^^^^^^
 
@@ -1128,9 +1088,10 @@ parameter, which all jobs in the bin receive.
 ``batch`` Queue Policy
 """""""""""""""""""""""
 
-The ``batch`` queue is the default queue for production work on Summit.
-Most work on Summit is handled through this queue. It enforces the
-following policies:
+The ``batch`` queue (and the ``batch-spi`` queue for Moderate Enhanced security
+enclave projects) is the default queue for production work on Summit.  Most
+work on Summit is handled through this queue. It enforces the following
+policies:
 
 -  Limit of (4) *eligible-to-run* jobs per user.
 -  Jobs in excess of the per user limit above will be placed into a
@@ -1147,8 +1108,9 @@ following policies:
 ``batch-hm`` Queue Policy
 """""""""""""""""""""""""
 
-The ``batch-hm`` queue is used to access Summit's high-memory nodes.
-Jobs may use all 54 nodes. It enforces the following policies:
+The ``batch-hm`` queue (and the ``batch-hm-spi`` queue for Moderate Enhanced
+security enclave projects) is used to access Summit's high-memory nodes.  Jobs
+may use all 54 nodes. It enforces the following policies:
 
 -  Limit of (4) *eligible-to-run* jobs per user.
 -  Jobs in excess of the per user limit above will be placed into a
@@ -1167,23 +1129,6 @@ Jobs may use all 54 nodes. It enforces the following policies:
 
 To submit a job to the ``batch-hm`` queue, add the ``-q batch-hm`` option to your
 ``bsub`` command or ``#BSUB -q batch-hm`` to your job script.
-
-
-Moderate Enhanced Projects ``batch-spi`` Queue Policy
-"""""""""""""""""""""""""""""""""""""""""""""""""""""
-The ``batch-spi`` queue is used by Summit's "Moderate Enhanced Enclave" projects. Projects in
-this enclave will be required to add ``-q batch-spi`` to their ``bsub`` command, or ``#BSUB -q batch-spi`` to
-their job scripts. Except for the enhanced security policies for jobs in these queues, all other queue properties are
-the same as the regular batch queue, including walltime limits based on node count, job aging priorities based on node
-count, and maximum number of jobs per user.
-
-Moderate Enhanced Projects ``batch-hm-spi`` Queue Policy
-""""""""""""""""""""""""""""""""""""""""""""""""""""""""
-The ``batch-hm-spi`` queue is used by Summit's "Moderate Enhanced Enclave" projects that also want to
-take advantage of Summit's high-memory nodes. Projects in this enclave that want to use the Summit
-high-memory nodes will need to add ``-q batch-hm-spi`` to their ``bsub`` command, or ``#BSUB -q batch-hm-spi`` to
-their job scripts. Except for the enhanced security policies for jobs in these queues, all other queue properties are the same 
-as the ``batch-hm`` queue, such as maximum walltime and number of eligible running jobs.
 
 
 ``killable`` Queue Policy
@@ -1224,13 +1169,13 @@ flag can be used at submit time.
 ``debug`` Queue Policy
 """"""""""""""""""""""""""
 
-The ``debug`` queue (and the ``debug-spi`` queue for Moderate Enhanced security enclave projects)
-can be used to access Summit's compute resources for short 
-non-production debug tasks.  The queue provides a higher priority compared
-to jobs of the same job size bin in production queues.  Production work and 
-job chaining in the debug queue is prohibited.  Each user is limited to one 
-job in any state in the debug queue at any one point. Attempts to submit multiple
-jobs to the debug queue will be rejected upon job submission.
+The ``debug`` queue (and the ``debug-spi`` queue for Moderate Enhanced security
+enclave projects) can be used to access Summit's compute resources for short
+non-production debug tasks.  The queue provides a higher priority compared to
+jobs of the same job size bin in production queues.  Production work and job
+chaining in the debug queue is prohibited.  Each user is limited to one job in
+any state in the debug queue at any one point. Attempts to submit multiple jobs
+to the debug queue will be rejected upon job submission.
 
 **debug job limits:**
 
@@ -1241,12 +1186,28 @@ jobs to the debug queue will be rejected upon job submission.
 +-------------+--------------+------------------------+---------------------------------+--------------------+
 
 To submit a job to the ``debug`` queue, add the ``-q debug`` option to your
-``bsub`` command or ``#BSUB -q debug`` to your job script. Moderate Enhanced projects would add ``-q debug-spi``
-to the ``bsub`` command or ``#BSUB -q debug-spi`` to job scripts.
+``bsub`` command or ``#BSUB -q debug`` to your job script.
 
 
 .. note::
     Production work and job chaining in the ``debug`` queue is prohibited.
+
+SPI/KDI Citadel Queue Policy (Moderate Enhanced Projects)
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+There are special queue names when submitting jobs to ``citadel.ccs.ornl.gov``
+(the Moderate Enhanced version of Summit). These queues are: ``batch-spi``,
+``batch-hm-spi``, and ``debug-spi``.  For example, to submit a job to the
+``batch-spi`` queue on Citadel, you would need ``-q batch-spi`` when using the
+``bsub`` command or ``#BSUB -q batch-spi`` when using a job script.
+
+Except for the enhanced security policies for jobs in these queues, all other
+queue properties are the same as the respective Summit queues described above,
+such as maximum walltime and number of eligible running jobs.
+
+.. warning::
+    If you submit a job to a "normal" Summit queue while on Citadel, such as
+    ``-q batch``, your job will be unable to launch.
 
 Allocation Overuse Policy
 ^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
Consolidated Citadel information to its own section

Removed references to mismatched OS versions on Citadel