### PR TITLE
Updating user guide for ML/AI precision behavior

### DIFF
--- a/systems/crusher_quick_start_guide.rst
+++ b/systems/crusher_quick_start_guide.rst
@@ -1063,11 +1063,13 @@ Notable Differences between Summit and Crusher
 
 This section details 'tips and tricks' and information of interest to users when porting from Summit to Crusher.
 
-Using reduced precision (FP16, FP32, and BF16 datatypes)
+Using reduced precision (FP16 and BF16 datatypes)
 --------------------------------------------------------
-Users using BF16, FP16, and FP32 datatypes for applications such as ML/AI training and low-precision matrix multiplication should be aware that the AMD MI250X GPU has different denormal handling than the V100 GPUs on Summit. On the MI250X, the V_DOT2 and the matrix instructions for FP32, FP16, BF16, flush input and output denormal values to zero. FP64 MFMA instructions do not flush input and output denormal values to zero. 
+Users leveraging BF16 and FP16 datatypes for applications such as ML/AI training and low-precision matrix multiplication should be aware that the AMD MI250X GPU has different denormal handling than the V100 GPUs on Summit. On the MI250X, the V_DOT2 and the matrix instructions for FP16 and BF16 flush input and output denormal values to zero. FP32 and FP64 MFMA instructions do not flush input and output denormal values to zero. 
 
-When training deep learning models using FP16 precision, some models may fail to converge with FP16 denorms flushed to zero. This occurs in operations encountering denormal values, and so is more likely to occur in FP16 because of a small dynamic range. BF16 and FP32 numbers have a larger dynamic range than FP16 numbers, and so are less likely to encounter denormal values.
+When training deep learning models using FP16 precision, some models may fail to converge with FP16 denorms flushed to zero. This occurs in operations encountering denormal values, and so is more likely to occur in FP16 because of a small dynamic range. BF16 numbers have a larger dynamic range than FP16 numbers and are less likely to encounter denormal values.
+
+AMD has provided a solution in ROCm 5.0 which modifies the behavior of Tensorflow, PyTorch, and rocBLAS. This modification starts with user input FP16 values, casting the intermediate FP16 values to BF16, and then casting back to FP16 output after the accumulate FP32 operations. In this way, the input and output types are unchanged. The behavior is enabled by default in machine learning frameworks and requires a special enum type to enable in rocBLAS. For more information, see the rocBLAS link below. 
 
 If you encounter significant differences when running using reduced precision, explore replacing non-converging models in FP16 with BF16, because of the greater dynamic range in BF16. We recommend using BF16 for ML models in general. If you have further questions or encounter issues, contact help@olcf.ornl.gov.
 


### PR DESCRIPTION
1. Removed mention of FP32 flushing denorms to zero (this was incorrect)
2. Added mention of AMD solution for frameworks and libraries