### PR TITLE
Update HIP module info on Summit

### DIFF
--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -4479,6 +4479,7 @@ Frontier today on Summit. To use HIP on Summit, you must load the HIP module:
     $ module load hip-cuda
 
 CUDA 11.4.0 or later must be loaded in order to load the hip-cuda module.
+hipBLAS, hipFFT, hipSOLVER, and hipSPARSE have also been added to hip-cuda.
 
 Learning to Program with HIP
 ----------------------------

--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -4476,9 +4476,9 @@ Frontier today on Summit. To use HIP on Summit, you must load the HIP module:
 
 ::
 
-    $ module load hip
+    $ module load hip-cuda
 
-This will automatically load the appropriate CUDA module as well.
+CUDA 11.4.0 or later must be loaded in order to load the hip-cuda module.
 
 Learning to Program with HIP
 ----------------------------

--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -4479,7 +4479,8 @@ Frontier today on Summit. To use HIP on Summit, you must load the HIP module:
     $ module load hip-cuda
 
 CUDA 11.4.0 or later must be loaded in order to load the hip-cuda module.
-hipBLAS, hipFFT, hipSOLVER, and hipSPARSE have also been added to hip-cuda.
+hipBLAS, hipFFT, hipSOLVER, hipSPARSE, and hipRAND have also been added
+to hip-cuda.
 
 Learning to Program with HIP
 ----------------------------


### PR DESCRIPTION
The name and behavior of the HIP module on Summit has changed.

There is probably more that can be said about what this release offers, specifically in regards to the new HIP marshalling libraries used for the cuda math libraries. That might be a larger documentation effort though, and I'm not sure it should delay correcting this piece now.