### PR TITLE
Add HPCToolkit section on Summit user guide

### DIFF
--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -2805,6 +2805,37 @@ trace files for Vampir to visualize.
 For detailed information about using Vampir on Summit and the builds available,
 please see the `Vampir Software Page <https://www.olcf.ornl.gov/software_package/vampir/>`__.
 
+HPCToolkit
+----------
+
+`HPCToolkit <http://hpctoolkit.org/>`__ is an integrated suite of tools for measurement and analysis of program performance on computers ranging from multicore desktop systems to the nation’s largest supercomputers. HPCToolkit provides accurate measurements of a program’s work, resource consumption, and inefficiency, correlates these metrics with the program’s source code, works with multilingual, fully optimized binaries, has very low measurement overhead, and scales to large parallel systems. HPCToolkit’s measurements provide support for analyzing a program execution cost, inefficiency, and scaling characteristics both within and across nodes of a parallel system.
+
+Programming models supported by HPCToolkit include MPI, OpenMP, OpenACC, CUDA, OpenCL, DPC++, HIP, RAJA, Kokkos, and others.
+
+Below is an example that generates a profile and loads the results in their GUI-based viewer.
+
+.. code:: bash
+
+    module use /gpfs/alpine/csc322/world-shared/modulefiles/ppc64le
+    module load hpctoolkit/2022.10.01
+
+    # 1. Profile and trace an application using CPU time and GPU performance counters
+    jsrun <jsrun_options> hpcrun -o <measurement_dir> -t -e CPUTIME -e gpu=nvidia <application>
+
+    # 2. Analyze the binary of executables and its dependent libraries
+    hpcstruct <measurement_dir>
+
+    # 3. Combine measurements with program structure information and generate a database
+    hpcprof -o <database_dir> <measurement_dir>
+
+    # 4. Understand performance issues by analyzing profiles and traces with the GUI
+    hpcviewer <database_dir>
+
+A quick summary of HPCToolkit options can be found in the `HPCTookit wiki page <https://gitlab.com/hpctoolkit/hpctoolkit/-/wikis/home>`__. More detailed information on HPCToolkit can be found in the `HPCToolkit User's Manual <http://hpctoolkit.org/manual/HPCToolkit-users-manual.pdf>`__.
+
+.. note::
+
+    HPCToolkit does not require a recompile to profile the code. It is recommended to use the -g optimization flag for attribution to source lines.
 
 .. _nvidia-v100-gpus:
 .. _NVIDIA Tesla V100:


### PR DESCRIPTION
The added section points to the modulefile for the newest HPCToolkit release version 2022.10.01.
Tested locally on my laptop.