### PR TITLE
pointed Crusher quick-start to correct node diagram

### DIFF
--- a/systems/crusher_quick_start_guide.rst
+++ b/systems/crusher_quick_start_guide.rst
@@ -24,7 +24,7 @@ Each Crusher compute node consists of [1x] 64-core AMD EPYC 7A53 "Optimized 3rd 
 
     The 8 GCDs contained in the 4 MI250X will show as 8 separate GPUs according to Slurm, ``ROCR_VISIBLE_DEVICES``, and the ROCr runtime, so from this point forward in the quick-start guide, we will simply refer to the GCDs as GPUs.
 
-.. image:: /images/Crusher_Node_Diagram.jpg
+.. image:: /images/Frontier_Node_Diagram.jpg
    :align: center
    :width: 100%
    :alt: Crusher node architecture diagram


### PR DESCRIPTION
This PR simply points to the updated Frontier node diagram that includes the 4 IF links between the GCDs on a common MI250X instead of a single darker red line. Until this PR is merged, you can see the difference between the Crusher and Frontier node diagrams in their user guides. 

The `diff` is literally:
```
-.. image:: /images/Crusher_Node_Diagram.jpg
+.. image:: /images/Frontier_Node_Diagram.jpg
```