### PR TITLE
Added KI for CMake on Summit for HIP

### DIFF
--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -3737,10 +3737,14 @@ created with information on the files that were copied.
 Known Issues
 ============
 
-Last Updated: 30 December 2022
+Last Updated: 07 February 2023
 
 Open Issues
 -----------
+
+HIP code cannot be built using CMake using hip::host/device or HIP language support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Using the ``hip-cuda/5.1.0`` module on Summit, applications cannot build using a ``CMakeLists.txt`` that requires HIP language support or references the ``hip::host`` and ``hip::device`` identifiers. There is no known workaround for this issue. Applications wishing to compile HIP code with CMake need to avoid using HIP language support or ``hip::host`` and ``hip::device`` identifiers.
 
 Unsupported CUDA versions do not work with GPU-aware MPI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^


### PR DESCRIPTION
HIP code on Summit cannot be compiled when relying on HIP language support or hip::device and hip::host keywords. For HIP language support, CMake relies on using `hipconfig --rocm-path`, which on Summit, evaluates to `/opt/rocm`, which doesn't exist. `hip::device` and `hip::host` are defined in a CMake file in `lib/hip/cmake` that is not present in the `hip-cuda` installation, but is present in ordinary ROCm installations. So these keywords have no meaning on Summit, leading to compile failures.