### PR TITLE
Update frontier_user_guide.rst

### DIFF
--- a/systems/frontier_user_guide.rst
+++ b/systems/frontier_user_guide.rst
@@ -557,7 +557,7 @@ If using ``PrgEnv-amd``:
     export MPICH_GPU_SUPPORT_ENABLED=1
     
     
-If using ``PrgEnv-cray`` or ``PrgEnv-gnu`` :   
+If using ``PrgEnv-cray``:   
 
 .. code:: bash
     


### PR DESCRIPTION
Removing some stray PrgEnv-GNUs from sections that imply hip usage.