### PR TITLE
Linking to XPMEM with hipcc for Frontier and Crusher.

### DIFF
--- a/systems/crusher_quick_start_guide.rst
+++ b/systems/crusher_quick_start_guide.rst
@@ -235,6 +235,8 @@ MPI
 | Cray MPICH     | ``cray-mpich`` | ``cc``, ``CC``, ``ftn`` (Cray compiler wrappers)    | MPI header files and linking is built into the Cray compiler wrappers         |
 |                |                +-----------------------------------------------------+-------------------------------------------------------------------------------+
 |                |                | ``hipcc``                                           | | ``-L${MPICH_DIR}/lib -lmpi``                                                |
+|                |                |                                                     | | ``${CRAY_XPMEM_POST_LINK_OPTS} -lxpmem``                                    |
+|                |                |                                                     | | ``${PE_MPICH_GTL_DIR_amd_gfx90a} ${PE_MPICH_GTL_LIBS_amd_gfx90a}``          |
 |                |                |                                                     | | ``-I${MPICH_DIR}/include``                                                  |
 +----------------+----------------+-----------------------------------------------------+-------------------------------------------------------------------------------+
 
@@ -283,7 +285,9 @@ To use GPU-aware Cray MPICH with ``hipcc``, users must include appropriate heade
 .. code:: bash
 
     -I${MPICH_DIR}/include
-    -L${MPICH_DIR}/lib -lmpi -L${CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa
+    -L${MPICH_DIR}/lib -lmpi \
+      ${CRAY_XPMEM_POST_LINK_OPTS} -lxpmem \
+      ${PE_MPICH_GTL_DIR_amd_gfx90a} ${PE_MPICH_GTL_LIBS_amd_gfx90a}
 
     HIPFLAGS = --amdgpu-target=gfx90a
 

--- a/systems/frontier_user_guide.rst
+++ b/systems/frontier_user_guide.rst
@@ -648,6 +648,8 @@ The MPI implementation available on Frontier is Cray's MPICH, which is "GPU-awar
 | Cray MPICH     | ``cray-mpich`` | ``cc``, ``CC``, ``ftn`` (Cray compiler wrappers)    | MPI header files and linking is built into the Cray compiler wrappers         |
 |                |                +-----------------------------------------------------+-------------------------------------------------------------------------------+
 |                |                | ``hipcc``                                           | | ``-L${MPICH_DIR}/lib -lmpi``                                                |
+|                |                |                                                     | | ``${CRAY_XPMEM_POST_LINK_OPTS} -lxpmem``                                    |
+|                |                |                                                     | | ``${PE_MPICH_GTL_DIR_amd_gfx90a} ${PE_MPICH_GTL_LIBS_amd_gfx90a}``          |
 |                |                |                                                     | | ``-I${MPICH_DIR}/include``                                                  |
 +----------------+----------------+-----------------------------------------------------+-------------------------------------------------------------------------------+
 
@@ -710,7 +712,9 @@ To use ``hipcc`` with GPU-aware Cray MPICH, use the following environment variab
 
 
     -I${MPICH_DIR}/include
-    -L${MPICH_DIR}/lib -lmpi ${PE_MPICH_GTL_DIR_amd_gfx90a} ${PE_MPICH_GTL_LIBS_amd_gfx90a}
+    -L${MPICH_DIR}/lib -lmpi \
+      ${CRAY_XPMEM_POST_LINK_OPTS} -lxpmem \
+      ${PE_MPICH_GTL_DIR_amd_gfx90a} ${PE_MPICH_GTL_LIBS_amd_gfx90a}
 
     HIPFLAGS = --amdgpu-target=gfx90a
     


### PR DESCRIPTION
MPI needs to link with XPMEM for faster on-node MPI with host buffers. This update documents the necessary arguments to get XPMEM when linking with hipcc. (The HPE Cray compiler wrappers link with XPMEM automatically.)