### PR TITLE
Updated OLCF Office Hour Information

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -14,7 +14,7 @@ OLCF User Documentation
 
     * `Submit a Support Ticket <https://www.olcf.ornl.gov/for-users/getting-started/submit-ticket/>`_
     * Email us at help@olcf.ornl.gov
-    * Sign-up to attend `OLCF Office Hours <https://www.olcf.ornl.gov/olcf-office-hours/>`_
+    * Sign-up to attend `OLCF Office Hours`_
 
 This technical documentation is a reference for the user community to
 efficiently use OLCF compute and storage resources.
@@ -24,6 +24,20 @@ Have an idea to improve this documentation? See :doc:`contributing/index`.
 Have a question? Write to us at -- help\@olcf.ornl.gov -- and consider the
 guidelines for :ref:`getting-help`.
 
+OLCF Office Hours
+---------------------
+
+    * Login to your Moderate account at `myOLCF <https://my.olcf.ornl.gov/login>`_
+    * Expand the OFFICE HOURS dropdown (on the sidebar navigation)
+    * There are 2 options to select: **Schedule a Time** and **View Your Scheduled Office Hour(s)**
+
+     **Schedule a Time** - Fill out the required fields in the form. On the date selection, use the arrows to scroll between
+     months and then click on a specific day. Once a day is selected, choose an available time slot by clicking the
+     `Reserve a Spot` button. Once all the required fields are filled in and a time slot is selected you can submit the form.
+
+     **View Your Scheduled Office Hour(s)** - This will show you your office hours for the current project you have selected.
+     If you have an office hour scheduled and don't see it there, make sure you have the correct project selected from the
+     `MY PROJECTS` dropdown on the top of the page.
 
 New User Quick Start
 ---------------------


### PR DESCRIPTION
Updated Office Hour information displayed to the users. Added information on how to register for office hours through myOLCF instead of the WP site.