### PR TITLE
Fix HSA_XNACK=0 hipMallocManaged access behavior

### DIFF
--- a/systems/crusher_quick_start_guide.rst
+++ b/systems/crusher_quick_start_guide.rst
@@ -1970,7 +1970,7 @@ Disabling XNACK will not necessarily result in an application failure, as most t
 +=============================================+===========================+============================================+=============================================+
 | System Allocator (malloc,new,allocate, etc) | CPU DDR4                  | Local read/write                           | Fatal Unhandled Page Fault                  |
 +---------------------------------------------+---------------------------+--------------------------------------------+---------------------------------------------+
-| hipMallocManaged                            | CPU DDR4                  | Zero copy read/write over Infinity Fabric  | Local read/write                            |
+| hipMallocManaged                            | CPU DDR4                  | Local read/write                           | Zero copy read/write over Infinity Fabric   |
 +---------------------------------------------+---------------------------+--------------------------------------------+---------------------------------------------+
 | hipHostMalloc                               | CPU DDR4                  | Local read/write                           | Zero copy read/write over Infinity Fabric   |
 +---------------------------------------------+---------------------------+--------------------------------------------+---------------------------------------------+

--- a/systems/frontier_user_guide.rst
+++ b/systems/frontier_user_guide.rst
@@ -3258,7 +3258,7 @@ Disabling XNACK will not necessarily result in an application failure, as most t
 +=============================================+===========================+============================================+=============================================+
 | System Allocator (malloc,new,allocate, etc) | CPU DDR4                  | Local read/write                           | Fatal Unhandled Page Fault                  |
 +---------------------------------------------+---------------------------+--------------------------------------------+---------------------------------------------+
-| hipMallocManaged                            | CPU DDR4                  | Zero copy read/write over Infinity Fabric  | Local read/write                            |
+| hipMallocManaged                            | CPU DDR4                  | Local read/write                           | Zero copy read/write over Infinity Fabric   |
 +---------------------------------------------+---------------------------+--------------------------------------------+---------------------------------------------+
 | hipHostMalloc                               | CPU DDR4                  | Local read/write                           | Zero copy read/write over Infinity Fabric   |
 +---------------------------------------------+---------------------------+--------------------------------------------+---------------------------------------------+


### PR DESCRIPTION
When we determined that hipMallocManaged memory was backed by DDR with XNACK off we switched the "initial physical location" but forgot to update the behavior to make it consistent.

The table should now be correct for the current behavior.