### PR TITLE
Fix broken link and adjust to OLCF User Assistance page

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,4 +16,4 @@ Just send us a [Pull Request](https://help.github.com/articles/using-pull-reques
 
 <hr>
 
-##### Contact: [OLCF User Assistance Group](https://www.olcf.ornl.gov/about-olcf/olcf-groups/user-assistance-outreach/), <help@olcf.ornl.gov>
+##### Contact: [OLCF User Assistance](https://www.olcf.ornl.gov/about-olcf/olcf-groups/user-assistance/), <help@olcf.ornl.gov>


### PR DESCRIPTION
The link at the bottom of the README was a 404. Changed it to the current User Assistance page.