### PR TITLE
Changing Alpine to Alpine2 in Andes, Summit Data user guides. Also re…

### DIFF
--- a/data/index.rst
+++ b/data/index.rst
@@ -44,6 +44,12 @@ Each project has a Project Home area on NFS, multiple Work areas on Spectrum Sca
 +--------------------------------+---------------------------------------------+---------+------------------------+-------------+--------+---------+---------+------------+-----------------------------------------+
 | Orion World Work               | ``/lustre/orion/[projid]/world-shared``     | M1,M2   | Lustre HPE ClusterStor | 775         |  50 TB | No      | 90 days | N/A [#f4]_ | Read/Write                              |
 +--------------------------------+---------------------------------------------+---------+------------------------+-------------+--------+---------+---------+------------+-----------------------------------------+
+| Alpine2 Member Work            | ``/gpfs/alpine2/[projid]/scratch/[userid]`` | M1, M2  | Spectrum Scale         | 700 [#f3]_  |  50 TB | No      | 90 days | N/A [#f4]_ | Read/Write                              |
++--------------------------------+---------------------------------------------+---------+------------------------+-------------+--------+---------+---------+------------+-----------------------------------------+
+| Alpine2 Project Work           | ``/gpfs/alpine2/[projid]/proj-shared``      | M1, M2  | Spectrum Scale         | 770         |  50 TB | No      | 90 days | N/A [#f4]_ | Read/Write                              |
++--------------------------------+---------------------------------------------+---------+------------------------+-------------+--------+---------+---------+------------+-----------------------------------------+
+| Alpine2 World Work             | ``/gpfs/alpine2/[projid]/world-shared``     | M1      | Spectrum Scale         | 775         |  50 TB | No      | 90 days | N/A [#f4]_ | Read/Write                              |
++--------------------------------+---------------------------------------------+---------+------------------------+-------------+--------+---------+---------+------------+-----------------------------------------+
 | Member Archive                 | ``/hpss/prod/[projid]/users/$USER``         | M1      | HPSS                   | 700         | 100 TB | No      | No      | 90 days    | No                                      |
 +--------------------------------+---------------------------------------------+---------+------------------------+-------------+--------+---------+---------+------------+-----------------------------------------+
 | Project Archive                | ``/hpss/prod/[projid]/proj-shared``         | M1      | HPSS                   | 770         | 100 TB | No      | No      | 90 days    | No                                      |
@@ -290,7 +296,7 @@ Moderate projects without export control restrictions are also allocated project
 Three Project Archive Areas Facilitae Collaboration on Archival Data
 --------------------------------------------------------------------
 
-To facilitate collaboration among researchers, the OLCF provides (3) distinct types of project-centric archival storage areas: *Member Archive* directories, *Project Archive* directories, and *World Archive* directories.  These directories should be used for storage of data not immediately needed in either the Project Home (NFS) areas or Project Work (Alpine) areas and to serve as a location to store backup copies of project-related files.
+To facilitate collaboration among researchers, the OLCF provides (3) distinct types of project-centric archival storage areas: *Member Archive* directories, *Project Archive* directories, and *World Archive* directories.  These directories should be used for storage of data not immediately needed in either the Project Home (NFS) areas or Project Work (Alpine2) areas and to serve as a location to store backup copies of project-related files.
 
 As with the three project work areas, the difference between these three areas lies in the accessibility of data to project members and to researchers outside of the project. Member Archive directories are accessible only by an individual project member by default, Project Archive directories are accessible by all project members, and World Archive directories are readable by any user on the system.
 
@@ -410,33 +416,42 @@ To keep the Lustre file system exceptionally performant, files that have not bee
 
 .. _data-alpine-ibm-spectrum-scale-filesystem:
 
-.. ************************************
-.. Alpine IBM Spectrum Scale Filesystem
-.. ************************************
+*************************************
+Alpine2 IBM Spectrum Scale Filesystem
+*************************************
 
-.. Summit mounts a POSIX-based IBM Spectrum Scale parallel filesystem called Alpine. Alpine's maximum capacity is 250 PB. It is consisted of 77  IBM Elastic Storage Server (ESS) GL4 nodes running IBM Spectrum Scale 5.x which are called Network Shared Disk (NSD) servers. Each IBM ESS GL4 node, is a scalable storage unit (SSU), constituted by two dual-socket IBM POWER9 storage servers, and a 4X EDR InfiniBand network for up to 100Gbit/sec of networking bandwidth.  The maximum performance of the final production system will be about 2.5 TB/s for sequential I/O and 2.2 TB/s for random I/O under FPP mode, which means each process, writes its own file. Metada operations are improved with around to minimum 50,000 file access per sec and aggregated up to 2.6 million accesses of 32KB small files.  
+Summit mounts a POSIX-based IBM Spectrum Scale parallel filesystem called Alpine2. It has a smaller capacity than its predecessor, Alpine, but is nearly as preformat.
+
+.. Alpine2's maximum capacity is 250 PB. It is consisted of 77  IBM Elastic Storage Server (ESS) GL4 nodes running IBM Spectrum Scale 5.x which are called Network Shared Disk (NSD) servers. Each IBM ESS GL4 node, is a scalable storage unit (SSU), constituted by two dual-socket IBM POWER9 storage servers, and a 4X EDR InfiniBand network for up to 100Gbit/sec of networking bandwidth.  The maximum performance of the final production system will be about 2.5 TB/s for sequential I/O and 2.2 TB/s for random I/O under FPP mode, which means each process, writes its own file. Metada operations are improved with around to minimum 50,000 file access per sec and aggregated up to 2.6 million accesses of 32KB small files.  
 
 
-.. .. figure:: /images/summit_nds_final.png
-..    :align: center
+.. figure:: /images/summit_nds_final.png
+   :align: center
 
-..    Figure 1. An example of the NDS servers on Summit
+   Figure 1. An example of the NDS servers on Summit
 
-.. ============================================
-.. Alpine Performance under non-ideal workloads
-.. ============================================
+ =============================================
+ Alpine2 Performance under non-ideal workloads
+ =============================================
 
-.. The I/O performance can be lower than the optimal one when you save one single shared file with non-optimal I/O pattern. Moreover, the previous performance results are achieved under an ideal system, the system is dedicated, and a specific number of compute nodes are used. The file system is shared across many users; the I/O performance can vary because other users that perform heavy I/O as also executing large scale jobs and stress the interconnection network.  Finally, if the I/O pattern is not aligned, then the I/O performance can be significantly lower than the ideal one.  Similar, related to the number of the concurrent users, is applied for the metadata operations, they can be lower than the expected performance.
+The I/O performance can be lower than the optimal one when you save one single shared file 
+with non-optimal I/O pattern. Moreover, the previous performance results are achieved under 
+an ideal system, the system is dedicated, and a specific number of compute nodes are used. 
+The file system is shared across many users; the I/O performance can vary because other users 
+that perform heavy I/O as also executing large scale jobs and stress the interconnection network.  
+Finally, if the I/O pattern is not aligned, then the I/O performance can be significantly lower 
+than the ideal one.  Similar, related to the number of the concurrent users, is applied for the 
+metadata operations, they can be lower than the expected performance.
 
-.. ====
-.. Tips
-.. ====
+====
+Tips
+====
 
-.. - For best performance on the IBM Spectrum Scale filesystem, use large page aligned I/O and asynchronous reads and writes. The filesystem blocksize is 16MB, the minimum fragment size is 16K so when a file under 16K is stored, it will still use 16K of the disk. Writing files of 16 MB or larger, will achieve better performance. All files are striped across LUNs which are distributed across all IO servers.
+- For best performance on the IBM Spectrum Scale filesystem, use large page aligned I/O and asynchronous reads and writes. The filesystem blocksize is 16MB, the minimum fragment size is 16K so when a file under 16K is stored, it will still use 16K of the disk. Writing files of 16 MB or larger, will achieve better performance. All files are striped across LUNs which are distributed across all IO servers.
 
-.. - If your application occupies up to two compute nodes and it requires a significant number of I/O operations, you could try to add the following flag in your job script  file and investigate if the total execution time is decreased. This flag could cause worse results, it depends on the application.
-.. 
-..                    ``#BSUB -alloc_flags maximizegpfs``
+- If your application occupies up to two compute nodes and it requires a significant number of I/O operations, you could try to add the following flag in your job script  file and investigate if the total execution time is decreased. This flag could cause worse results, it depends on the application.
+
+                   ``#BSUB -alloc_flags maximizegpfs``
 
 ======================================================================
 Major difference between Lustre HPE ClusterStor and IBM Spectrum Scale

--- a/services_and_applications/jupyter/overview.rst
+++ b/services_and_applications/jupyter/overview.rst
@@ -89,8 +89,8 @@ Hardware Resources
     - NCCS filesystem access (GPFS and NFS)
 
     .. note::
-      You have the same filesystem access as if you were on Summit, to both NFS and
-      GPFS, as you will be working under your standard OLCF UID.
+      You have the same filesystem access as if you were on Frontier, to both NFS and
+      Lustre, as you will be working under your standard OLCF UID.
 
 .. tabbed:: Open JupyterHub
 
@@ -289,7 +289,7 @@ The below steps apply for either the CPU or GPU lab.
 .. note::
    Conda environments created this way are only usable in JupyterLab. You can't
    create an environment within JupyterLab and use these environments on other machines
-   like Summit or Andes to run jobs. You will need to recreate the environment separately
+   like Frontier or Andes to run jobs. You will need to recreate the environment separately
    on those machines.
 
 Manually stopping your JupyterLab session

--- a/services_and_applications/slate/getting_started.rst
+++ b/services_and_applications/slate/getting_started.rst
@@ -25,7 +25,7 @@ by emailing **help@olcf.ornl.gov**.
 | - Existing OLCF Project ID
 | - Project PI
 | - Enclave (i.e. Open or Moderate Enclave - Onyx or Marble respectively)
-|   **NOTE:** Summit is in Moderate
+|   **NOTE:** Frontier is in Moderate
 | - Description (i.e. How you will use Slate)
 | - Resource Request (i.e. CPU/Memory/Storage requirements - Default is
 |   8CPU/16GB/50GB respectively)
@@ -39,7 +39,7 @@ able to reach it from your laptop on ORNL WiFi as well as the VPN).
 +-----------------------------------------------------------------------------+-------------------------------------------------------------------------------------+
 | Cluster                                                                     | URL                                                                                 |
 +=============================================================================+=====================================================================================+
-|  Marble (Moderate Production cluster with access to Summit/Alpine)          | `Marble Web Console - https://marble.ccs.ornl.gov <https://marble.ccs.ornl.gov/>`_  |
+|  Marble (Moderate Production cluster with access to Frontier/Orion)         | `Marble Web Console - https://marble.ccs.ornl.gov <https://marble.ccs.ornl.gov/>`_  |
 +-----------------------------------------------------------------------------+-------------------------------------------------------------------------------------+
 |  Onyx   (Open Production Cluster with access to Wolf)                       | `Onyx Web Console - https://onyx.ccs.ornl.gov <https://onyx.ccs.ornl.gov/>`_        |
 +-----------------------------------------------------------------------------+-------------------------------------------------------------------------------------+
@@ -102,7 +102,7 @@ Test login with OC Tool
 +-----------------------------------------------------------------------------+--------------------------------------+
 | Cluster                                                                     | URL                                  |
 +=============================================================================+======================================+
-|  Marble (Moderate Production cluster with access to Summit/Alpine)          | `<https://api.marble.ccs.ornl.gov>`_ |
+|  Marble (Moderate Production cluster with access to Frontier/Orion)         | `<https://api.marble.ccs.ornl.gov>`_ |
 +-----------------------------------------------------------------------------+--------------------------------------+
 |  Onyx   (Open Production Cluster with access to Wolf)                       | `<https://api.onyx.ccs.ornl.gov>`_   |
 +-----------------------------------------------------------------------------+--------------------------------------+

--- a/services_and_applications/slate/overview.rst
+++ b/services_and_applications/slate/overview.rst
@@ -17,11 +17,11 @@ Kubernetes. The *Slate* service today consists two user facing OpenShift cluster
 Marble Cluster
 ==============
 
-Marble is in the Moderate security enclave and has access to Summit (:ref:`summit-user-guide`) and Alpine (GPFS)
+Marble is in the Moderate security enclave and has access to Frontier and Orion Lustre. 
 
 Marble is a heterogeneus cluster of 30 nodes with 10 Gigabit ethernet connectivity. Marble
 has a node pool of GPU nodes with 3x NVIDIA V100 each, a node pool with Infiniband connectivity
-to Summit and GPFS access, and a node pool of standard compute nodes.
+to Frontier and Lustre access, and a node pool of standard compute nodes.
 
 Onyx Cluster
 ============

--- a/services_and_applications/slate/overview.rst
+++ b/services_and_applications/slate/overview.rst
@@ -17,7 +17,7 @@ Kubernetes. The *Slate* service today consists two user facing OpenShift cluster
 Marble Cluster
 ==============
 
-Marble is in the Moderate security enclave and has access to Frontier and Orion Lustre. 
+Marble is in the Moderate security enclave and has access to Frontier and Orion (Lustre). 
 
 Marble is a heterogeneus cluster of 30 nodes with 10 Gigabit ethernet connectivity. Marble
 has a node pool of GPU nodes with 3x NVIDIA V100 each, a node pool with Infiniband connectivity

--- a/systems/andes_user_guide.rst
+++ b/systems/andes_user_guide.rst
@@ -82,8 +82,8 @@ For more information on connecting to OLCF resources, see :ref:`connecting-to-ol
 File systems
 ------------
 
-The OLCF's center-wide :ref:`data-orion-lustre-hpe-clusterstor-filesystem` name Orion
-is available on Andes for computational work.  An NFS-based file system provides
+The OLCF's center-wide :ref:`data-orion-lustre-hpe-clusterstor-filesystem` and Summit's 
+Alpine2 are available on Andes for computational work.  An NFS-based file system provides
 :ref:`data-user-home-directories-nfs` and :ref:`data-project-home-directories-nfs`.
 Additionally, the OLCF's :ref:`data-hpss` provides archival spaces.
 

--- a/systems/frontier_user_guide.rst
+++ b/systems/frontier_user_guide.rst
@@ -134,7 +134,11 @@ The Frontier nodes are connected with [4x] HPE Slingshot 200 Gbps (25 GB/s) NICs
 File Systems
 ------------
 
-Frontier is connected to Orion, a parallel filesystem based on Lustre and HPE ClusterStor, with a 679 PB usable namespace (``/lustre/orion/``). In addition to Frontier, Orion is available on the OLCF's data transfer nodes. It is not available from Summit. Data will not be automatically transferred from Alpine to Orion. Frontier also has access to the center-wide NFS-based filesystem (which provides user and project home areas). Each compute node has two 1.92TB Non-Volatile Memory storage devices. See :ref:`frontier-data-storage` for more information. 
+Frontier is connected to Orion, a parallel filesystem based on Lustre and HPE ClusterStor, with a 679 PB usable 
+namespace (``/lustre/orion/``). In addition to Frontier, Orion is available on the OLCF's data transfer nodes and on the Andes cluster. 
+Orion is not available from Summit and Frontier does not mount Summit's Alpine2 filesystem. 
+Frontier also has access to the center-wide NFS-based filesystem (which provides user and project home areas). 
+Each compute node has two 1.92TB Non-Volatile Memory storage devices. See :ref:`frontier-data-storage` for more information. 
 
 Frontier connects to the center’s High Performance Storage System (HPSS) - for user and project archival storage - users can log in to the :ref:`dtn-user-guide` to move data to/from HPSS.
 

--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -124,9 +124,8 @@ level) that connect cabinets together.
 File Systems
 ------------
 
-Summit is connected to an IBM Spectrum Scale™ filesystem providing 250PB
-of storage capacity with a peak write speed of 2.5 TB/s. Summit also has
-access to the center-wide NFS-based filesystem (which provides user and
+Summit is connected to an IBM Spectrum Scale™ filesystem named Alpine2.
+Summit also has access to the center-wide NFS-based filesystem (which provides user and
 project home areas) and has access to the center’s High Performance
 Storage System (HPSS) for user and project archival storage.
 


### PR DESCRIPTION
Moving Alpine to Alpine2 in the doc. I will need to do another update when we get Alpine2 specs. 
Changed:
Data guide
Andes guide
Summit guide
Marble guide (removed mention of Alpine for now) 