### PR TITLE
Updated Frontier user guide for December 2023 PE update

### DIFF
--- a/software/software-news.rst
+++ b/software/software-news.rst
@@ -31,7 +31,7 @@ Going forward our core software (i.e software independent of compiler type/versi
 called `Core` with the version being in the format `year/month`. Additionally explicit suffixes have been added to modules to indicate MPI, OpenMP, and GPU support. 
 All modules that depend on ROCm are suffixed with `-gpu`. The same is true for packages with mpi `-mpi` and
 openmp `-omp`. Software is built to target CPE releases based on compiler (e.g. cce, amd or gcc), cray-mpich, and ROCm versions.
-If you have an :ref:`unsupported combination <supported combinations of compiler, mpi and rocm>` of those modules you may not see certain parts of the normal software stack.
+If you have an :ref:`unsupported combination <understanding-the-compatibility-of-compilers-rocm-and-cray-mpich>` of those modules you may not see certain parts of the normal software stack.
 
 Please contact help@olcf.ornl.gov if you encounter any issues or have questions.
 

--- a/systems/frontier_user_guide.rst
+++ b/systems/frontier_user_guide.rst
@@ -726,6 +726,27 @@ However, the AMD and CCE compilers are both LLVM/Clang-based, and it is recommen
 CCE's module version indicates the base LLVM version, but for AMD, you must run ``amdclang --version``.
 For example, ROCm/5.3.0 is based on LLVM 15.0.0.
 It is strongly discouraged to use ROCm/5.3.0 with CCE/16.0.1, which is based on LLVM 16.
+The following table shows the recommended ROCm version for each CCE version, along with the CPE version:
+
++-------------+-------+---------------------------+
+|    CCE      |  CPE  | Recommended ROCm Version  |
++=============+=======+===========================+
+|   15.0.0    | 22.12 | 5.3.0                     |
++-------------+-------+---------------------------+
+|   15.0.1    | 23.03 | 5.3.0                     |
++-------------+-------+---------------------------+
+|   16.0.0    | 23.05 | 5.5.1                     |
++-------------+-------+---------------------------+
+|   16.0.1    | 23.09 | 5.5.1                     |
++-------------+-------+---------------------------+
+|   17.0.0    | 23.12 | 5.7.0 or 5.7.1            |
++-------------+-------+---------------------------+
+
+.. note::
+
+    Recall that the CPE module is a meta-module that simple loads the correct version for each Cray-provided module (e.g. CCE, Cray MPICH, Cray Libsci).
+    This is the best way to load the versions of modules from a specific CrayPE release.
+
 
 Compatible ROCm & Cray MPICH versions
 """""""""""""""""""""""""""""""""""""

--- a/systems/frontier_user_guide.rst
+++ b/systems/frontier_user_guide.rst
@@ -3657,6 +3657,7 @@ On Tuesday, July 16, 2024, Frontier's system software will be upgraded. The foll
 
 -  ROCm 5.7.1 and HPE/Cray PE 23.12 will become default.
 -  The system will be upgraded to the AMD GPU 6.7.0 device driver (ROCm 6.1.0 release).
+-  Please note major changes in the AMD and GNU programming environments detailed in Known Issues `OLCFDEV-1799 <https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#olcfdev-1799-new-rocm-module-layout-for-prgenv-amd>`_ and `OLCFDEV_1801 <https://docs.olcf.ornl.gov/systems/frontier_user_guide.html#olcfdev-1801-new-prgenv-gnu-module-implementation>`_.
 
 Users are encouraged to try the versions that will become default and report any issues to help@olcf.ornl.gov.
 


### PR DESCRIPTION
Includes changes for the following:

- Greater emphasis on CRAY_LD_LIBRARY_PATH
- Adds section about compatible CrayPE modules
- Remove mention of amd-mixed in favor of ROCm
- Make changes to AMD moduleflow -- PrgEnv-amd now REQUIRES a `rocm` module to load the toolchain properly
- Updated information about `gcc-native`
- Updates Roofline computation to reflect new information provided by AMD during a roofline working group call.