### PR TITLE
Updating rocprof to include rocprofv3, updating Omnitrace/perf

### DIFF
--- a/systems/frontier_user_guide.rst
+++ b/systems/frontier_user_guide.rst
@@ -3352,7 +3352,7 @@ For example:
     each MPI rank only has 1 GPU, so each rank sees its GPU as GPU 0.
 
 Additional steps for rocprofv3
-==============================
+""""""""""""""""""""""""""""""
 
 ``rocprofv3`` does not do any counter aggregation in large counter-collecting runs, so you will find that you get one directory per `pmc` block in the ``rocprofv3`` input file, named ``pmc_1``, ``pmc_2``, and so on.
 If you want to have a single file output, like with ``rocprof``, you will need to run the Python script located in ``/sw/frontier/amdsw/rocprofiler-extras/bin/convert-rocprofv3-to-rocprofv1.py``.

--- a/systems/frontier_user_guide.rst
+++ b/systems/frontier_user_guide.rst
@@ -3489,6 +3489,14 @@ ROCm Compute Profiler is a Python tool with non-standard dependencies.
 As such, we provide a conda environment built using the miniforge3 module if we detect that you do not have your own Python version loaded (ie, if ``which python3`` returns ``/usr/bin/python3``).
 Warnings will be printed out when the module is loaded if the pre-built conda environment is not loaded.
 
+For example, to use rocprofiler-compute:
+
+.. code::
+ 
+    module load rocm
+    module load rocprofiler-compute
+
+
 As a rule of thumb, always load the ``rocprofiler-compute`` module last (especially after you load a ROCm module).
 If you load a new version of ROCm, you will need to re-load ``rocprofiler-compute``.
 


### PR DESCRIPTION
Beginning in ROCm/6.2.x, rocprofv3 is the recommended text-only profiler. Additionally, Omniperf and Omnitrace have been rebranded to ROCm Compute and Systems profilers.