### PR TITLE
Remove 2024 changes page from index

### DIFF
--- a/systems/index.rst
+++ b/systems/index.rst
@@ -7,7 +7,6 @@ Systems
 .. toctree::
    :maxdepth: 2
 
-   2024_olcf_system_changes
    frontier_user_guide
    citadel_user_guide
    andes_user_guide


### PR DESCRIPTION
Now that HPSS access has been removed we can remove the notable events page