### PR TITLE
Top-level container example is for rocm/6.2.4 to match examples repo

### DIFF
--- a/software/containers_on_frontier.rst
+++ b/software/containers_on_frontier.rst
@@ -28,7 +28,7 @@ containers on Frontier. Some of the examples will refer to files in the
 Building and running a container image from a base Linux distribution for MPI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This example will walk through building up a container image with OpenSUSE 15.4, MPICH 3.4.2, and ROCm 5.7.1
+This example will walk through building up a container image with OpenSUSE 15.6, MPICH 3.4a2, and ROCm 6.2.4
 for a GPU aware MPI code.
 
 * Clone the ``olcf_containers_examples`` repository
@@ -38,10 +38,10 @@ for a GPU aware MPI code.
      git clone https://github.com/olcf/olcf_containers_examples/
 
 * Navigate to ``frontier/containers_on_frontier_docs/gpu_aware_mpi_example``
-* In that directory, the ``opensusempich342rocm571.def`` is an Apptainer definition file that will build a container image with MPICH 3.4.2 and ROCm 5.7.1, along with copying the ``ping_pong_gpu_aware.cpp`` file from the directory into the container image, and then compiling it.
+* In that directory, the ``opensusempich342rocm624.def`` is an Apptainer definition file that will build a container image with MPICH 3.4a2 and ROCm 6.2.4, along with copying the ``ping_pong_gpu_aware.cpp`` file from the directory into the container image, and then compiling it.
 
   * If you would like to inspect and make changes to the definition file to modify what the container has, feel free to do so. Inspect the definition file to understand how we build MPICH and ROCm inside the container.
-  * MPICH 3.4.2 is required to be installed in your container image and build your MPI application with it if you want to run MPI on Frontier with containers. This is because cray-mpich is based on MPICH 3.4.2 and is ABI compatible. Later in the job script we will be mounting the Cray MPICH libraries into the container so that the application in the container will link and use those libraries. This is necessary for native performance.
+  * MPICH 3.4a2 is required to be installed in your container image and build your MPI application with it if you want to run MPI on Frontier with containers. This is because cray-mpich is based on MPICH 3.4a2 and is ABI compatible. Later in the job script we will be mounting the Cray MPICH libraries into the container so that the application in the container will link and use those libraries. This is necessary for native performance.
 
 * To build the container image (the SIF file), run
   ::
@@ -51,10 +51,10 @@ for a GPU aware MPI code.
 
   * Apptainer builds the container image in the SIF file format. Unlike Podman, Apptainer gives you a single file for your image that you can later run as your container.
 
-* Submit the ``submit.sbatch`` job script to launch the container with srun and run the ``ping_pong_gpu_aware.exe`` that was built in the container to perform the ping-pong communication across two nodes.
+* Submit the ``submit624.sbatch`` job script to launch the container with srun and run the ``ping_pong_gpu_aware.exe`` that was built in the container to perform the ping-pong communication across two nodes.
 
   * Remember to replace the ``#SBATCH -Astf007`` with your project ID.
-  * If you inspect the ``submit.sbatch`` file, you will see some modules being loaded as well as some environment variables being set. Read the comment above each for the explanations. These environment variables are required in order to run containerized MPI applications with Apptainer, with communication performance close to native and to provide GPU aware MPI.
+  * If you inspect the ``submit624.sbatch`` file, you will see some modules being loaded as well as some environment variables being set. Read the comment above each for the explanations. These environment variables are required in order to run containerized MPI applications with Apptainer, with communication performance close to native and to provide GPU aware MPI.
 
 
 Pushing your Apptainer image to an OCI Registry supporting ORAS (e.g. DockerHub)
@@ -95,13 +95,13 @@ Building an image on top of an existing image (local, docker image, OCI artifact
 
 In building container images, we often have to build on an existing image. This could be a local image in ones working directory, an OCI image from an OCI registry, or Apptainer SIF file that was stored as an OCI artifact in an OCI registry. One of the benefits of building images on top of existing images is simplified and easy to follow definition files instead of single and large ones.
 
-This example will look at building a container image for testing collective communications for GPUs using RCCL. The image will be built on top of an existing image that builds ROCM and MPICH since both are required for RCCL. Specifically, MPICH 3.4.2 since Cray-mpich is based on it.
+This example will look at building a container image for testing collective communications for GPUs using RCCL. The image will be built on top of an existing image that builds ROCM and MPICH since both are required for RCCL. Specifically, MPICH 3.4a2 since Cray-mpich is based on it.
 
 
 * Navigate to ``frontier/containers_on_frontier_docs/rccltests`` of the previously cloned github repo.
 * The Apptainer definition file for building the RCCL container image is rcclmpich342rocm624.def.
 
-  * This builds on the existing opensusempich342rocm624.sif image from a previous example. Hence, MPICH 3.4.2 and ROCm 6.2.4 are used in this image.
+  * This builds on the existing opensusempich342rocm624.sif image from a previous example. Hence, MPICH 3.4a2 and ROCm 6.2.4 are used in this image.
   * To specify that we are building this container image off the existing opensusempich342rocm624.sif image, we indicate next to the Bootstrap Keyword (under the definition file Header), localimage, for image in your workdir.
 
     ::

--- a/software/containers_on_frontier.rst
+++ b/software/containers_on_frontier.rst
@@ -28,7 +28,7 @@ containers on Frontier. Some of the examples will refer to files in the
 Building and running a container image from a base Linux distribution for MPI
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-This example will walk through building up a container image with OpenSUSE 15.6, MPICH 3.4a2, and ROCm 6.2.4
+This example will walk through building up a container image with OpenSUSE 15.6, MPICH 3.4.2, and ROCm 6.2.4
 for a GPU aware MPI code.
 
 * Clone the ``olcf_containers_examples`` repository
@@ -38,10 +38,10 @@ for a GPU aware MPI code.
      git clone https://github.com/olcf/olcf_containers_examples/
 
 * Navigate to ``frontier/containers_on_frontier_docs/gpu_aware_mpi_example``
-* In that directory, the ``opensusempich342rocm624.def`` is an Apptainer definition file that will build a container image with MPICH 3.4a2 and ROCm 6.2.4, along with copying the ``ping_pong_gpu_aware.cpp`` file from the directory into the container image, and then compiling it.
+* In that directory, the ``opensusempich342rocm624.def`` is an Apptainer definition file that will build a container image with MPICH 3.4.2 and ROCm 6.2.4, along with copying the ``ping_pong_gpu_aware.cpp`` file from the directory into the container image, and then compiling it.
 
   * If you would like to inspect and make changes to the definition file to modify what the container has, feel free to do so. Inspect the definition file to understand how we build MPICH and ROCm inside the container.
-  * MPICH 3.4a2 is required to be installed in your container image and build your MPI application with it if you want to run MPI on Frontier with containers. This is because cray-mpich is based on MPICH 3.4a2 and is ABI compatible. Later in the job script we will be mounting the Cray MPICH libraries into the container so that the application in the container will link and use those libraries. This is necessary for native performance.
+  * MPICH 3.4.2 is required to be installed in your container image and build your MPI application with it if you want to run MPI on Frontier with containers. This is because MPICH 3.4.2 is ABI compatible with the ``cray-mpich-abi`` module even though cray-mpich is based on MPICH 3.4a2. Later in the job script we will be mounting the Cray MPICH libraries into the container so that the application in the container will link and use those libraries. This is necessary for native performance.
 
 * To build the container image (the SIF file), run
   ::
@@ -95,13 +95,13 @@ Building an image on top of an existing image (local, docker image, OCI artifact
 
 In building container images, we often have to build on an existing image. This could be a local image in ones working directory, an OCI image from an OCI registry, or Apptainer SIF file that was stored as an OCI artifact in an OCI registry. One of the benefits of building images on top of existing images is simplified and easy to follow definition files instead of single and large ones.
 
-This example will look at building a container image for testing collective communications for GPUs using RCCL. The image will be built on top of an existing image that builds ROCM and MPICH since both are required for RCCL. Specifically, MPICH 3.4a2 since Cray-mpich is based on it.
+This example will look at building a container image for testing collective communications for GPUs using RCCL. The image will be built on top of an existing image that builds ROCM and MPICH since both are required for RCCL. Specifically, MPICH 3.4.2 since Cray-mpich is compatible with it.
 
 
 * Navigate to ``frontier/containers_on_frontier_docs/rccltests`` of the previously cloned github repo.
 * The Apptainer definition file for building the RCCL container image is rcclmpich342rocm624.def.
 
-  * This builds on the existing opensusempich342rocm624.sif image from a previous example. Hence, MPICH 3.4a2 and ROCm 6.2.4 are used in this image.
+  * This builds on the existing opensusempich342rocm624.sif image from a previous example. Hence, MPICH 3.4.2 and ROCm 6.2.4 are used in this image.
   * To specify that we are building this container image off the existing opensusempich342rocm624.sif image, we indicate next to the Bootstrap Keyword (under the definition file Header), localimage, for image in your workdir.
 
     ::


### PR DESCRIPTION
Since https://github.com/olcf/olcf_containers_examples/pull/9 was merged, this is the corresponding documentation update. It updates the file names and software versions for the default container example.

This should not conflict with a parallel PR: https://github.com/olcf/olcf-user-docs/pull/1023