### PR TITLE
Legacy systems

### DIFF
--- a/systems/ascent_user_guide.rst
+++ b/systems/ascent_user_guide.rst
@@ -1,0 +1,18 @@
+.. _ascent-user-guide:
+
+******
+Ascent
+******
+
+System Overview
+===============
+
+Ascent is a stand-alone 18-node system with the same architecture and design
+as Summit. It's most often utilized as a resource for OLCF training events,
+workshops, and conferences. Ascent exists in the NCCS Open Security Enclave,
+which is subject to fewer restrictions than the Moderate Security Enclave that
+houses systems such as Summit. This means that participants in training events can go through a streamlined version of the approval process before being granted access.
+
+As the Ascent user environment is almost identical to Summit, additional
+information can be found in the :ref:`training-system-ascent` section of the
+:ref:`summit-user-guide`.

--- a/systems/ascent_user_guide.rst
+++ b/systems/ascent_user_guide.rst
@@ -1,8 +1,14 @@
+:no-search:
 .. _ascent-user-guide:
 
-******
-Ascent
-******
+*****************
+Ascent User Guide
+*****************
+
+.. warning::
+
+  This system was decommissioned on November 15, 2024 and is no longer online.
+  Information here is presented as an archive and is no longer updated.
 
 System Overview
 ===============

--- a/systems/crusher_quick_start_guide.rst
+++ b/systems/crusher_quick_start_guide.rst
@@ -1,0 +1,2304 @@
+.. _crusher-quick-start-guide:
+
+*************************
+Crusher Quick-Start Guide
+*************************
+
+.. warning::
+    **The Crusher Test and Development System will be decommissioned on April 12th, 2024.** The
+    file systems that were available on Crusher are still accessible from the Home
+    server and the Data Transfer Nodes (DTNs), so all your data will remain accessible.
+    If you do not have access to other OLCF systems, your project will move to data-only
+    for 30-days. If you have any questions, please contact help@olcf.ornl.gov.
+
+.. _crusher-system-overview:
+
+System Overview
+===============
+
+Crusher is an National Center for Computational Sciences (NCCS) moderate-security system that contains identical hardware and similar software as the upcoming Frontier system. It is used as an early-access testbed for Center for Accelerated Application Readiness (CAAR) and Exascale Computing Project (ECP) teams as well as NCCS staff and our vendor partners. The system has 2 cabinets, the first with 128 compute nodes and the second with 64 compute nodes, for a total of 192 compute nodes.
+
+.. _crusher-compute-nodes:
+
+Crusher Compute Nodes
+---------------------
+
+Each Crusher compute node consists of [1x] 64-core AMD EPYC 7A53 "Optimized 3rd Gen EPYC" CPU (with 2 hardware threads per physical core) with access to 512 GB of DDR4 memory. Each node also contains [4x] AMD MI250X, each with 2 Graphics Compute Dies (GCDs) for a total of 8 GCDs per node. The programmer can think of the 8 GCDs as 8 separate GPUs, each having 64 GB of high-bandwidth memory (HBM2E). The CPU is connected to each GCD via Infinity Fabric CPU-GPU, allowing a peak host-to-device (H2D) and device-to-host (D2H) bandwidth of 36+36 GB/s. The 2 GCDs on the same MI250X are connected with Infinity Fabric GPU-GPU with a peak bandwidth of 200 GB/s. The GCDs on different MI250X are connected with Infinity Fabric GPU-GPU in the arrangement shown in the Crusher Node Diagram below, where the peak bandwidth ranges from 50-100 GB/s based on the number of Infinity Fabric connections between individual GCDs.
+
+.. note::
+
+    **TERMINOLOGY:**
+
+    The 8 GCDs contained in the 4 MI250X will show as 8 separate GPUs according to Slurm, ``ROCR_VISIBLE_DEVICES``, and the ROCr runtime, so from this point forward in the quick-start guide, we will simply refer to the GCDs as GPUs.
+
+.. image:: /images/Frontier_Node_Diagram.jpg
+   :align: center
+   :width: 100%
+   :alt: Crusher node architecture diagram
+
+.. note::
+    There are [4x] NUMA domains per node and [2x] L3 cache regions per NUMA for a total of [8x] L3 cache regions. The 8 GPUs are each associated with one of the L3 regions as follows:
+
+    NUMA 0:
+
+    * hardware threads 000-007, 064-071 | GPU 4
+    * hardware threads 008-015, 072-079 | GPU 5
+    
+    NUMA 1:
+
+    * hardware threads 016-023, 080-087 | GPU 2
+    * hardware threads 024-031, 088-095 | GPU 3
+
+    NUMA 2:
+
+    * hardware threads 032-039, 096-103 | GPU 6
+    * hardware threads 040-047, 104-111 | GPU 7
+
+    NUMA 3:
+
+    * hardware threads 048-055, 112-119 | GPU 0
+    * hardware threads 056-063, 120-127 | GPU 1
+
+
+System Interconnect
+-------------------
+
+The Crusher nodes are connected with [4x] HPE Slingshot 200 Gbps (25 GB/s) NICs providing a node-injection bandwidth of 800 Gbps (100 GB/s).
+
+File Systems
+------------
+
+Crusher is connected to the center-wide IBM Spectrum Scale™ filesystem providing 250 PB of storage capacity with a peak write speed of 2.5 TB/s. Crusher also has access to the center-wide NFS-based filesystem (which provides user and project home areas). While Crusher does not have *direct* access to the center’s Nearline archival storage system (Kronos) - for user and project archival storage - users can log in to the moderate DTNs to move data to/from Kronos or use the "OLCF Kronos" Globus collection. For more information on using Kronos, see the :ref:`kronos` section. 
+
+GPUs
+----
+
+Crusher contains a total of 768 AMD MI250X. The AMD MI250X has a peak performance of 53 TFLOPS in double-precision for modeling and simulation. Each MI250X contains 2 GPUs, where each GPU has a peak performance of 26.5 TFLOPS (double-precision), 110 compute units, and 64 GB of high-bandwidth memory (HBM2) which can be accessed at a peak of 1.6 TB/s. The 2 GPUs on an MI250X are connected with Infinity Fabric with a bandwidth of 200 GB/s (in both directions simultaneously).
+
+----
+
+Connecting
+==========
+
+To connect to Crusher, ``ssh`` to ``crusher.olcf.ornl.gov``. For example:
+
+.. code-block:: bash
+
+    $ ssh <username>@crusher.olcf.ornl.gov
+
+For more information on connecting to OLCF resources, see :ref:`connecting-to-olcf`.
+
+----
+
+Data and Storage
+================
+
+For more detailed information about center-wide file systems and data archiving available on Crusher, please refer to the pages on :ref:`data-storage-and-transfers`, but the two subsections below give a quick overview of NFS and Lustre storage spaces.
+
+NFS Filesystem
+--------------
+
++---------------------+---------------------------------------------+----------------+-------------+--------+---------+---------+------------+------------------+
+| Area                | Path                                        | Type           | Permissions |  Quota | Backups | Purged  | Retention  | On Compute Nodes |
++=====================+=============================================+================+=============+========+=========+=========+============+==================+
+| User Home           | ``/ccs/home/[userid]``                      | NFS            | User set    |  50 GB | Yes     | No      | 90 days    | Read-only        |
++---------------------+---------------------------------------------+----------------+-------------+--------+---------+---------+------------+------------------+
+| Project Home        | ``/ccs/proj/[projid]``                      | NFS            | 770         |  50 GB | Yes     | No      | 90 days    | Read-only        |
++---------------------+---------------------------------------------+----------------+-------------+--------+---------+---------+------------+------------------+
+
+Lustre Filesystem
+-----------------
+
++---------------------+---------------------------------------------+------------------------+-------------+--------+---------+---------+------------+------------------+
+| Area                | Path                                        | Type                   | Permissions |  Quota | Backups | Purged  | Retention  | On Compute Nodes |
++=====================+=============================================+========================+=============+========+=========+=========+============+==================+
+| Member Work         | ``/lustre/orion/[projid]/scratch/[userid]`` | Lustre HPE ClusterStor | 700         |  50 TB | No      | 90 days | N/A        | Yes              |
++---------------------+---------------------------------------------+------------------------+-------------+--------+---------+---------+------------+------------------+
+| Project Work        | ``/lustre/orion/[projid]/proj-shared``      | Lustre HPE ClusterStor | 770         |  50 TB | No      | 90 days | N/A        | Yes              |
++---------------------+---------------------------------------------+------------------------+-------------+--------+---------+---------+------------+------------------+
+| World Work          | ``/lustre/orion/[projid]/world-shared``     | Lustre HPE ClusterStor | 775         |  50 TB | No      | 90 days | N/A        | Yes              |
++---------------------+---------------------------------------------+------------------------+-------------+--------+---------+---------+------------+------------------+
+
+
+----
+
+Programming Environment
+=======================
+
+Crusher users are provided with many pre-installed software packages and scientific libraries. To facilitate this, environment management tools are used to handle necessary changes to the shell.
+
+Environment Modules (Lmod)
+--------------------------
+
+Environment modules are provided through `Lmod <https://lmod.readthedocs.io/en/latest/>`__, a Lua-based module system for dynamically altering shell environments. By managing changes to the shell’s environment variables (such as ``PATH``, ``LD_LIBRARY_PATH``, and ``PKG_CONFIG_PATH``), Lmod allows you to alter the software available in your shell environment without the risk of creating package and version combinations that cannot coexist in a single environment.
+
+General Usage
+^^^^^^^^^^^^^
+
+The interface to Lmod is provided by the ``module`` command:
+
++------------------------------------+-------------------------------------------------------------------------+
+| Command                            | Description                                                             |
++====================================+=========================================================================+
+| ``module -t list``                 | Shows a terse list of the currently loaded modules                      |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module avail``                   | Shows a table of the currently available modules                        |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module help <modulename>``       | Shows help information about ``<modulename>``                           |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module show <modulename>``       | Shows the environment changes made by the ``<modulename>`` modulefile   |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module spider <string>``         | Searches all possible modules according to ``<string>``                 |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module load <modulename> [...]`` | Loads the given ``<modulename>``\(s) into the current environment       |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module use <path>``              | Adds ``<path>`` to the modulefile search cache and ``MODULESPATH``      |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module unuse <path>``            | Removes ``<path>`` from the modulefile search cache and ``MODULESPATH`` |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module purge``                   | Unloads all modules                                                     |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module reset``                   | Resets loaded modules to system defaults                                |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module update``                  | Reloads all currently loaded modules                                    |
++------------------------------------+-------------------------------------------------------------------------+
+
+Searching for Modules
+^^^^^^^^^^^^^^^^^^^^^
+
+Modules with dependencies are only available when the underlying dependencies, such as compiler families, are loaded. Thus, module avail will only display modules that are compatible with the current state of the environment. To search the entire hierarchy across all possible dependencies, the ``spider`` sub-command can be used as summarized in the following table.
+
++------------------------------------------+--------------------------------------------------------------------------------------+
+| Command                                  | Description                                                                          |
++==========================================+======================================================================================+
+| ``module spider``                        | Shows the entire possible graph of modules                                           |
++------------------------------------------+--------------------------------------------------------------------------------------+
+| ``module spider <modulename>``           | Searches for modules named ``<modulename>`` in the graph of possible modules         |
++------------------------------------------+--------------------------------------------------------------------------------------+
+| ``module spider <modulename>/<version>`` | Searches for a specific version of ``<modulename>`` in the graph of possible modules |
++------------------------------------------+--------------------------------------------------------------------------------------+
+| ``module spider <string>``               | Searches for modulefiles containing ``<string>``                                     |
++------------------------------------------+--------------------------------------------------------------------------------------+
+
+Compilers
+---------
+
+Cray, AMD, and GCC compilers are provided through modules on Crusher. The Cray and AMD compilers are both based on LLVM/Clang. There is also a system/OS versions of GCC available in ``/usr/bin``. The table below lists details about each of the module-provided compilers.
+
+.. note::
+
+    It is highly recommended to use the Cray compiler wrappers (``cc``, ``CC``, and ``ftn``) whenever possible. See the next section for more details.
+
+
++--------+-------------------------+-----------------+----------+-------------------+---------------------------------+
+| Vendor | Programming Environment | Compiler Module | Language | Compiler Wrapper  | Compiler                        |
++========+=========================+=================+==========+===================+=================================+
+| Cray   | ``PrgEnv-cray``         | ``cce``         | C        | ``cc``            | ``craycc``                      |
+|        |                         |                 +----------+-------------------+---------------------------------+
+|        |                         |                 | C++      | ``CC``            | ``craycxx`` or ``crayCC``       |
+|        |                         |                 +----------+-------------------+---------------------------------+
+|        |                         |                 | Fortran  | ``ftn``           | ``crayftn``                     |
++--------+-------------------------+-----------------+----------+-------------------+---------------------------------+
+| AMD    | ``PrgEnv-amd``          | ``rocm``        | C        | ``cc``            | ``amdclang``                    |
+|        |                         |                 +----------+-------------------+---------------------------------+
+|        |                         |                 | C++      | ``CC``            | ``amdclang++``                  |
+|        |                         |                 +----------+-------------------+---------------------------------+
+|        |                         |                 | Fortran  | ``ftn``           | ``amdflang``                    |
++--------+-------------------------+-----------------+----------+-------------------+---------------------------------+
+| GCC    | ``PrgEnv-gnu``          | ``gcc``         | C        | ``cc``            | ``${GCC_PATH}/bin/gcc``         |
+|        |                         |                 +----------+-------------------+---------------------------------+
+|        |                         |                 | C++      | ``CC``            | ``${GCC_PATH}/bin/g++``         |
+|        |                         |                 +----------+-------------------+---------------------------------+
+|        |                         |                 | Fortran  | ``ftn``           | ``${GCC_PATH}/bin/gfortran``    |
++--------+-------------------------+-----------------+----------+-------------------+---------------------------------+
+
+
+Cray Programming Environment and Compiler Wrappers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Cray provides ``PrgEnv-<compiler>`` modules (e.g., ``PrgEnv-cray``) that load compatible components of a specific compiler toolchain. The components include the specified compiler as well as MPI, LibSci, and other libraries. Loading the ``PrgEnv-<compiler>`` modules also defines a set of compiler wrappers for that compiler toolchain that automatically add include paths and link in libraries for Cray software. Compiler wrappers are provided for C (``cc``), C++ (``CC``), and Fortran (``ftn``).
+
+.. note::
+   Use the ``-craype-verbose`` flag to display the full include and link information used by the Cray compiler wrappers. This must be called on a file to see the full output (e.g., ``CC -craype-verbose test.cpp``).
+
+MPI
+---
+
+The MPI implementation available on Crusher is Cray's MPICH, which is "GPU-aware" so GPU buffers can be passed directly to MPI calls.
+
+----
+
+Compiling
+=========
+
+This section covers how to compile for different programming models using the different compilers covered in the previous section.
+
+MPI
+---
+
++----------------+----------------+-----------------------------------------------------+-------------------------------------------------------------------------------+
+| Implementation | Module         | Compiler                                            | Header Files & Linking                                                        |
++================+================+=====================================================+===============================================================================+
+| Cray MPICH     | ``cray-mpich`` | ``cc``, ``CC``, ``ftn`` (Cray compiler wrappers)    | MPI header files and linking is built into the Cray compiler wrappers         |
+|                |                +-----------------------------------------------------+-------------------------------------------------------------------------------+
+|                |                | ``hipcc``                                           | | ``-L${MPICH_DIR}/lib -lmpi``                                                |
+|                |                |                                                     | | ``${CRAY_XPMEM_POST_LINK_OPTS} -lxpmem``                                    |
+|                |                |                                                     | | ``${PE_MPICH_GTL_DIR_amd_gfx90a} ${PE_MPICH_GTL_LIBS_amd_gfx90a}``          |
+|                |                |                                                     | | ``-I${MPICH_DIR}/include``                                                  |
++----------------+----------------+-----------------------------------------------------+-------------------------------------------------------------------------------+
+
+GPU-Aware MPI
+^^^^^^^^^^^^^
+
+To use GPU-aware Cray MPICH, users must set the following modules and environment variables:
+
+.. code:: bash
+    
+    module load craype-accel-amd-gfx90a
+    module load rocm
+
+    export MPICH_GPU_SUPPORT_ENABLED=1
+
+.. note::
+
+    There are extra steps needed to enable GPU-aware MPI on Crusher, which depend on the compiler that is used (see 1. and 2. below).
+    
+
+1. Compiling with the Cray compiler wrappers, ``cc`` or ``CC``
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+To use GPU-aware Cray MPICH with the Cray compiler wrappers, the following environment variables must be set before compiling. These variables are automatically set by the ``cray-mpich`` modulefile:
+
+.. code:: bash
+
+    ## These must be set before compiling so the executable picks up GTL
+    PE_MPICH_GTL_DIR_amd_gfx90a="-L${CRAY_MPICH_ROOTDIR}/gtl/lib"
+    PE_MPICH_GTL_LIBS_amd_gfx90a="-lmpi_gtl_hsa"
+
+In addition, the following header files and libraries must be included:
+
+.. code:: bash
+
+    -I${ROCM_PATH}/include
+    -L${ROCM_PATH}/lib -lamdhip64
+
+where the include path implies that ``#include <hip/hip_runtime.h>`` is included in the source file.
+
+2. Compiling with ``hipcc``
+"""""""""""""""""""""""""""
+
+To use GPU-aware Cray MPICH with ``hipcc``, users must include appropriate headers, libraries, and flags:
+
+.. code:: bash
+
+    -I${MPICH_DIR}/include
+    -L${MPICH_DIR}/lib -lmpi \
+      ${CRAY_XPMEM_POST_LINK_OPTS} -lxpmem \
+      ${PE_MPICH_GTL_DIR_amd_gfx90a} ${PE_MPICH_GTL_LIBS_amd_gfx90a}
+
+    HIPFLAGS = --amdgpu-target=gfx90a
+
+Determining the Compatibility of Cray MPICH and ROCm
+""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+Releases of ``cray-mpich`` are each built with a specific version of ROCm, and compatibility across multiple versions is not guaranteed. OLCF will maintain compatible default modules when possible. If using non-default modules, you can determine compatibility by reviewing the *Product and OS Dependencies* section in the ``cray-mpich`` release notes. This can be displayed by running ``module show cray-mpich/<version>``. If the notes indicate compatibility with *AMD ROCM X.Y or later*, only use ``rocm/X.Y.Z`` modules. If using a non-default version of ``cray-mpich``, you must add ``${CRAY_MPICH_ROOTDIR}/gtl/lib`` to either your ``LD_LIBRARY_PATH`` at run time or your executable's rpath at build time.
+
+The compatibility table below was determined by linker testing with all current combinations of ``cray-mpich`` and ``rocm`` modules on Crusher.
+
++------------+------------------------------------------+
+| cray-mpich |                   ROCm                   |
++============+==========================================+
+|   8.1.12   |               4.5.2, 4.5.0               |
++------------+------------------------------------------+
+|   8.1.14   |               4.5.2, 4.5.0               |
++------------+------------------------------------------+
+|   8.1.15   | 5.4.0, 5.3.0, 5.2.0, 5.1.0, 5.0.2, 5.0.0 |
++------------+------------------------------------------+
+|   8.1.16   | 5.4.0, 5.3.0, 5.2.0, 5.1.0, 5.0.2, 5.0.0 |
++------------+------------------------------------------+
+|   8.1.17   | 5.4.0, 5.3.0, 5.2.0, 5.1.0, 5.0.2, 5.0.0 |
++------------+------------------------------------------+
+|   8.1.18   | 5.4.0, 5.3.0, 5.2.0, 5.1.0, 5.0.2, 5.0.0 |
++------------+------------------------------------------+
+|   8.1.19   | 5.4.0, 5.3.0, 5.2.0, 5.1.0, 5.0.2, 5.0.0 |
++------------+------------------------------------------+
+|   8.1.21   | 5.4.0, 5.3.0, 5.2.0, 5.1.0, 5.0.2, 5.0.0 |
++------------+------------------------------------------+
+|   8.1.23   | 5.4.0, 5.3.0, 5.2.0, 5.1.0, 5.0.2, 5.0.0 |
++------------+------------------------------------------+
+
+OpenMP
+------
+
+This section shows how to compile with OpenMP using the different compilers covered above.
+
++--------+----------+-----------+----------------------------------------------+-------------------------------------+
+| Vendor | Module   | Language  | Compiler                                     | OpenMP flag (CPU thread)            |
++========+==========+===========+==============================================+=====================================+
+| Cray   | ``cce``  | C, C\+\+  | | ``cc`` (wraps ``craycc``)                  | ``-fopenmp``                        |
+|        |          |           | | ``CC`` (wraps ``crayCC``)                  |                                     |
+|        |          +-----------+----------------------------------------------+-------------------------------------+
+|        |          | Fortran   | ``ftn`` (wraps ``crayftn``)                  | | ``-homp``                         |
+|        |          |           |                                              | | ``-fopenmp`` (alias)              |
++--------+----------+-----------+----------------------------------------------+-------------------------------------+
+| AMD    | ``rocm`` | | C       | | ``cc`` (wraps ``amdclang``)                | ``-fopenmp``                        |
+|        |          | | C++     | | ``CC`` (wraps ``amdclang++``)              |                                     |
+|        |          | | Fortran | | ``ftn`` (wraps ``amdflang``)               |                                     |
++--------+----------+-----------+----------------------------------------------+-------------------------------------+
+| GCC    | ``gcc``  | | C       | | ``cc`` (wraps ``$GCC_PATH/bin/gcc``)       | ``-fopenmp``                        |
+|        |          | | C++     | | ``CC`` (wraps ``$GCC_PATH/bin/g++``)       |                                     |
+|        |          | | Fortran | | ``ftn`` (wraps ``$GCC_PATH/bin/gfortran``) |                                     |
++--------+----------+-----------+----------------------------------------------+-------------------------------------+
+
+OpenMP GPU Offload
+------------------
+
+This section shows how to compile with OpenMP Offload using the different compilers covered above.
+
+.. note::
+
+    Make sure the ``craype-accel-amd-gfx90a`` module is loaded when using OpenMP offload.
+
++--------+----------+-----------+----------------------------------------------+----------------------------------------------+
+| Vendor | Module   | Language  | Compiler                                     | OpenMP flag (GPU)                            |
++========+==========+===========+==============================================+==============================================+
+| Cray   | ``cce``  | C         | | ``cc`` (wraps ``craycc``)                  | ``-fopenmp``                                 |
+|        |          | C\+\+     | | ``CC`` (wraps ``crayCC``)                  |                                              |
+|        |          +-----------+----------------------------------------------+----------------------------------------------+
+|        |          | Fortran   | ``ftn`` (wraps ``crayftn``)                  | | ``-homp``                                  |
+|        |          |           |                                              | | ``-fopenmp`` (alias)                       |
++--------+----------+-----------+----------------------------------------------+----------------------------------------------+
+| AMD    | ``rocm`` | | C       | | ``cc`` (wraps ``amdclang``)                | ``-fopenmp``                                 |
+|        |          | | C\+\+   | | ``CC`` (wraps ``amdclang++``)              |                                              |
+|        |          | | Fortran | | ``ftn`` (wraps ``amdflang``)               |                                              |
+|        |          |           | | ``hipcc`` (requires flags below)           |                                              |
++--------+----------+-----------+----------------------------------------------+----------------------------------------------+
+
+.. note::
+
+    If invoking ``amdclang``, ``amdclang++``, or ``amdflang`` directly, or using ``hipcc`` you will need to add:
+    ``-fopenmp -target x86_64-pc-linux-gnu -fopenmp-targets=amdgcn-amd-amdhsa -Xopenmp-target=amdgcn-amd-amdhsa -march=gfx90a``.
+
+HIP
+---
+
+This section shows how to compile HIP codes using the Cray compiler wrappers and ``hipcc`` compiler driver.
+
+.. note::
+
+    Make sure the ``craype-accel-amd-gfx90a`` module is loaded when compiling HIP with the Cray compiler wrappers.
+
++-------------------+--------------------------------------------------------------------------------------------------------------------------+
+| Compiler          | Compile/Link Flags, Header Files, and Libraries                                                                          |
++===================+==========================================================================================================================+
+| | ``CC``          | | ``CFLAGS = -std=c++11 -D__HIP_ROCclr__ -D__HIP_ARCH_GFX90A__=1 --rocm-path=${ROCM_PATH} --offload-arch=gfx90a -x hip`` |
+| | Only with       | | ``LFLAGS = --rocm-path=${ROCM_PATH}``                                                                                  |
+| | ``PrgEnv-cray`` | | ``-L${ROCM_PATH}/lib -lamdhip64``                                                                                      |
+| | ``PrgEnv-amd``  |                                                                                                                          |
++-------------------+--------------------------------------------------------------------------------------------------------------------------+
+| ``hipcc``         | | Can be used directly to compile HIP source files.                                                                      |
+|                   | | To see what is being invoked within this compiler driver, issue the command, ``hipcc --verbose``                       |
+|                   | | To explicitly target AMD MI250X, use ``--amdgpu-target=gfx90a``                                                        |
++-------------------+--------------------------------------------------------------------------------------------------------------------------+
+
+HIP + OpenMP CPU Threading
+--------------------------
+
+This section describes how to compile HIP + OpenMP CPU threading hybrid codes.
+For all compiler toolchains, HIP kernels and kernel launch calls (ie ``hipLaunchKernelGGL``) cannot be implemented in the same file that requires ``-fopenmp``.
+HIP API calls (``hipMalloc``, ``hipMemcpy``) are allowed in files that require ``-fopenmp``.
+HIP source files should be compiled into object files using the instructions in the ``HIP`` section, with the ``-c`` flag added to generate an object file.
+OpenMP and other non-HIP source files should be compiled into object files using the instructions in the ``OpenMP`` section.
+Then these object files should be linked using the following link flags: ``-fopenmp -L${ROCM_PATH}/lib -lamdhip64``.
+
+SYCL
+----
+
+This section shows how to compile SYCL codes using the DPC++ compiler.
+
+.. note::
+
+    Make sure the ``ums ums015 dpcpp`` module is loaded when compiling SYCL with ``clang`` or ``clang++``.
+
++-------------------+--------------------------------------------------------------------------------------------------------------------------+
+| Compiler          | Compile/Link Flags, Header Files, and Libraries                                                                          |
++===================+==========================================================================================================================+
+| | ``clang``       | | ``CFLAGS = -fsycl -fsycl-targets=amdgcn-amd-amdhsa -Xsycl-target-backend --offload-arch=gfx90a``                       |
+| | ``clang++``     | |                                                                                                                        |
++-------------------+--------------------------------------------------------------------------------------------------------------------------+
+
+.. note::
+
+    These compilers are built weekly from the latest open-source rather than releases. As such, these compilers will get new features and updates quickly but may break on occasion. If you experience regressions, please load an older version of the module rather than the latest.
+
+----
+
+Running Jobs
+============
+
+This section describes how to run programs on the Crusher compute nodes, including a brief overview of Slurm and also how to map processes and threads to CPU cores and GPUs.
+
+Slurm Workload Manager
+----------------------
+
+`Slurm <https://slurm.schedmd.com/>`__ is the workload manager used to interact with the compute nodes on Crusher. In the following subsections, the most commonly used Slurm commands for submitting, running, and monitoring jobs will be covered, but users are encouraged to visit the official documentation and man pages for more information.
+
+Batch Scheduler and Job Launcher
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Slurm provides 3 ways of submitting and launching jobs on Crusher's compute nodes: batch scripts, interactive, and single-command. The Slurm commands associated with these methods are shown in the table below and examples of their use can be found in the related subsections. Please note that regardless of the submission method used, the job will launch on compute nodes, with the first compute in the allocation serving as head-node.
+
++------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``sbatch`` | | Used to submit a batch script to allocate a Slurm job allocation. The script contains options preceded with ``#SBATCH``.                                                   |
+|            | | (see Batch Scripts section below)                                                                                                                                          |
++------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``salloc`` | | Used to allocate an interactive Slurm job allocation, where one or more job steps (i.e., ``srun`` commands) can then be launched on the allocated resources (i.e., nodes). |
+|            | | (see Interactive Jobs section below)                                                                                                                                       |
++------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``srun``   | | Used to run a parallel job (job step) on the resources allocated with sbatch or ``salloc``.                                                                                |
+|            | | If necessary, srun will first create a resource allocation in which to run the parallel job(s).                                                                            |
+|            | | (see Single Command section below)                                                                                                                                         |
++------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+
+Batch Scripts
+"""""""""""""
+
+A batch script can be used to submit a job to run on the compute nodes at a later time. In this case, stdout and stderr will be written to a file(s) that can be opened after the job completes. Here is an example of a simple batch script:
+
+.. code-block:: bash
+   :linenos:
+
+   #!/bin/bash
+   #SBATCH -A <project_id>
+   #SBATCH -J <job_name>
+   #SBATCH -o %x-%j.out
+   #SBATCH -t 00:05:00
+   #SBATCH -p <partition>
+   #SBATCH -N 2
+
+   srun -n4 --ntasks-per-node=2 ./a.out
+
+The Slurm submission options are preceded by ``#SBATCH``, making them appear as comments to a shell (since comments begin with ``#``). Slurm will look for submission options from the first line through the first non-comment line. Options encountered after the first non-comment line will not be read by Slurm. In the example script, the lines are:
+
++------+-------------------------------------------------------------------------------+
+| Line | Description                                                                   |
++======+===============================================================================+
+| 1    | [Optional] shell interpreter line                                             |
++------+-------------------------------------------------------------------------------+
+| 2    | OLCF project to charge                                                        |
++------+-------------------------------------------------------------------------------+
+| 3    | Job name                                                                      |
++------+-------------------------------------------------------------------------------+
+| 4    | stdout file name ( ``%x`` represents job name, ``%j`` represents job id)      |
++------+-------------------------------------------------------------------------------+
+| 5    | Walltime requested (``HH:MM:SS``)                                             |
++------+-------------------------------------------------------------------------------+
+| 6    | Batch queue                                                                   |
++------+-------------------------------------------------------------------------------+
+| 7    | Number of compute nodes requested                                             |
++------+-------------------------------------------------------------------------------+
+| 8    | Blank line                                                                    |
++------+-------------------------------------------------------------------------------+
+| 9    | ``srun`` command to launch parallel job (requesting 4 processes - 2 per node) |
++------+-------------------------------------------------------------------------------+
+
+Interactive Jobs
+""""""""""""""""
+
+To request an interactive job where multiple job steps (i.e., multiple ``srun`` commands) can be launched on the allocated compute node(s), the ``salloc`` command can be used:
+
+.. code-block:: bash
+
+   $ salloc -A <project_id> -J <job_name> -t 00:05:00 -p <partition> -N 2
+   salloc: Granted job allocation 4258
+   salloc: Waiting for resource configuration
+   salloc: Nodes crusher[010-011] are ready for job
+
+   $ srun -n 4 --ntasks-per-node=2 ./a.out
+   <output printed to terminal>
+
+   $ srun -n 2 --ntasks-per-node=1 ./a.out
+   <output printed to terminal>
+
+Here, ``salloc`` is used to request an allocation of 2 compute nodes for 5 minutes. Once the resources become available, the user is granted access to the compute nodes (``crusher010`` and ``crusher011`` in this case) and can launch job steps on them using ``srun``.
+
+.. _single-command-crusher:
+
+Single Command (non-interactive)
+""""""""""""""""""""""""""""""""
+
+.. code-block:: bash
+
+   $ srun -A <project_id> -t 00:05:00 -p <partition> -N 2 -n 4 --ntasks-per-node=2 ./a.out
+   <output printed to terminal>
+
+The job name and output options have been removed since stdout/stderr are typically desired in the terminal window in this usage mode.
+
+Common Slurm Submission Options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The table below summarizes commonly-used Slurm job submission options:
+
++-----------------------------------+---------------------------------------------------------------+
+| ``-A <project_id>``               | Project ID to charge                                          |
++-----------------------------------+---------------------------------------------------------------+
+| ``-J <job_name>``                 | Name of job                                                   |
++-----------------------------------+---------------------------------------------------------------+
+| ``-p <partition>``                | Partition / batch queue                                       |
++-----------------------------------+---------------------------------------------------------------+
+| ``-t <time>``                     | Wall clock time <``HH:MM:SS``>                                |
++-----------------------------------+---------------------------------------------------------------+
+| ``-N <number_of_nodes>``          | Number of compute nodes                                       |
++-----------------------------------+---------------------------------------------------------------+
+| ``-o <file_name>``                | Standard output file name                                     |
++-----------------------------------+---------------------------------------------------------------+
+| ``-e <file_name>``                | Standard error file name                                      |
++-----------------------------------+---------------------------------------------------------------+
+| ``--threads-per-core=<threads>``  | Number of active hardware threads per core [1 (default) or 2] |
++-----------------------------------+---------------------------------------------------------------+
+
+For more information about these and/or other options, please see the ``sbatch`` man page.
+
+Other Common Slurm Commands
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The table below summarizes commonly-used Slurm commands:
+
++--------------+---------------------------------------------------------------------------------------------------------------------------------+
+| ``sinfo``    | | Used to view partition and node information.                                                                                  |
+|              | | E.g., to view user-defined details about the batch queue:                                                                     |
+|              | | ``sinfo -p batch -o "%15N %10D %10P %10a %10c %10z"``                                                                         |
++--------------+---------------------------------------------------------------------------------------------------------------------------------+
+| ``squeue``   | | Used to view job and job step information for jobs in the scheduling queue.                                                   |
+|              | | E.g., to see all jobs from a specific user:                                                                                   |
+|              | | ``squeue -l -u <user_id>``                                                                                                    |
++--------------+---------------------------------------------------------------------------------------------------------------------------------+
+| ``sacct``    | | Used to view accounting data for jobs and job steps in the job accounting log (currently in the queue or recently completed). |
+|              | | E.g., to see a list of specified information about all jobs submitted/run by a users since 1 PM on January 4, 2021:           |
+|              | | ``sacct -u <username> -S 2021-01-04T13:00:00 -o "jobid%5,jobname%25,user%15,nodelist%20" -X``                                 |
++--------------+---------------------------------------------------------------------------------------------------------------------------------+
+| ``scancel``  | | Used to signal or cancel jobs or job steps.                                                                                   |
+|              | | E.g., to cancel a job:                                                                                                        |
+|              | | ``scancel <jobid>``                                                                                                           |
++--------------+---------------------------------------------------------------------------------------------------------------------------------+
+| ``scontrol`` | | Used to view or modify job configuration.                                                                                     |
+|              | | E.g., to place a job on hold:                                                                                                 |
+|              | | ``scontrol hold <jobid>``                                                                                                     |
++--------------+---------------------------------------------------------------------------------------------------------------------------------+
+
+----
+
+Slurm Compute Node Partitions
+-----------------------------
+
+Crusher's compute nodes are contained within a single Slurm partition (queue) for both CAAR and ECP projects. Please see the table below for details.
+
+
+Partition
+^^^^^^^^^^^^^^
+
+The CAAR and ECP "batch" partition consists of 192 total compute nodes. On a per-project basis, each user can have 2 running and 2 eligible jobs at a time, with up to 20 jobs submitted.
+
++-----------------+--------------+
+| Number of Nodes | Max Walltime |
++=================+==============+
+| 1 - 8           | 8 hours      |
++-----------------+--------------+
+| 9 - 64          | 4 hours      |
++-----------------+--------------+
+| 65 - 160        | 2 hours      |
++-----------------+--------------+
+
+.. note::
+    If CAAR or ECP teams require a temporary exception to this policy, please email help@olcf.ornl.gov with your request and it will be given to the OLCF Resource Utilization Council (RUC) for review.
+
+Process and Thread Mapping
+--------------------------
+
+This section describes how to map processes (e.g., MPI ranks) and process threads (e.g., OpenMP threads) to the CPUs and GPUs on Crusher. The :ref:`crusher-compute-nodes` diagram will be helpful when reading this section to understand which physical CPU cores (and hardware threads) your processes and threads run on. 
+
+.. note::
+
+    Users are highly encouraged to use the CPU- and GPU-mapping programs used in the following sections to check their understanding of the job steps (i.e., ``srun`` commands) the intend to use in their actual jobs.
+
+CPU Mapping
+^^^^^^^^^^^
+
+In this sub-section, a simple MPI+OpenMP "Hello, World" program (`hello_mpi_omp <https://code.ornl.gov/olcf/hello_mpi_omp>`__) will be used to clarify the mappings. Slurm's :ref:`interactive` method was used to request an allocation of 1 compute node for these examples: ``salloc -A <project_id> -t 30 -p <parition> -N 1``
+
+The ``srun`` options used in this section are (see ``man srun`` for more information):
+
++----------------------------------+-------------------------------------------------------------------------------------------------------+
+| ``-c, --cpus-per-task=<ncpus>``  | | Request that ``ncpus`` be allocated per process (default is 1).                                     |
+|                                  | | (``ncpus`` refers to hardware threads)                                                              |
++----------------------------------+-------------------------------------------------------------------------------------------------------+
+| ``--threads-per-core=<threads>`` | | In task layout, use the specified maximum number of hardware threads per core                       |
+|                                  | | (default is 1; there are 2 hardware threads per physical CPU core).                                 |
+|                                  | | Must also be set in ``salloc`` or ``sbatch`` if using 2 threads per core.                           |
++----------------------------------+-------------------------------------------------------------------------------------------------------+
+|  ``--cpu-bind=threads``          | | Bind tasks to CPUs.                                                                                 |
+|                                  | | ``threads`` - Automatically generate masks binding tasks to threads.                                |
+|                                  | | (Although this option is not explicitly used in these examples, it is the default CPU binding.)     |
++----------------------------------+-------------------------------------------------------------------------------------------------------+
+
+.. note::
+
+    In the ``srun`` man page (and so the table above), threads refers to hardware threads.
+
+2 MPI ranks - each with 2 OpenMP threads
+""""""""""""""""""""""""""""""""""""""""
+
+In this example, the intent is to launch 2 MPI ranks, each of which spawn 2 OpenMP threads, and have all of the 4 OpenMP threads run on different physical CPU cores.
+
+**First (INCORRECT) attempt**
+
+To set the number of OpenMP threads spawned per MPI rank, the ``OMP_NUM_THREADS`` environment variable can be used. To set the number of MPI ranks launched, the ``srun`` flag ``-n`` can be used.
+
+.. code-block:: bash
+
+    $ export OMP_NUM_THREADS=2
+    $ srun -N1 -n2 ./hello_mpi_omp | sort
+
+    WARNING: Requested total thread count and/or thread affinity may result in
+    oversubscription of available CPU resources!  Performance may be degraded.
+    Explicitly set OMP_WAIT_POLICY=PASSIVE or ACTIVE to suppress this message.
+    Set CRAY_OMP_CHECK_AFFINITY=TRUE to print detailed thread-affinity messages.
+    WARNING: Requested total thread count and/or thread affinity may result in
+    oversubscription of available CPU resources!  Performance may be degraded.
+    Explicitly set OMP_WAIT_POLICY=PASSIVE or ACTIVE to suppress this message.
+    Set CRAY_OMP_CHECK_AFFINITY=TRUE to print detailed thread-affinity messages.
+
+    MPI 000 - OMP 000 - HWT 001 - Node crusher001
+    MPI 000 - OMP 001 - HWT 001 - Node crusher001
+    MPI 001 - OMP 000 - HWT 009 - Node crusher001
+    MPI 001 - OMP 001 - HWT 009 - Node crusher001
+
+The first thing to notice here is the ``WARNING`` about oversubscribing the available CPU cores. Also, the output shows each MPI rank did spawn 2 OpenMP threads, but both OpenMP threads ran on the same hardware thread (for a given MPI rank). This was not the intended behavior; each OpenMP thread was meant to run on its own physical CPU core.
+
+The problem here arises from two default settings; 1) each MPI rank is only allocated 1 physical CPU core (``-c 1``) and, 2) only 1 hardware thread per physical CPU core is enabled (``--threads-per-core=1``). So in this case, each MPI rank only has 1 physical core (with 1 hardware thread) to run on - including any threads the process spawns - hence the WARNING and undesired behavior.
+
+**Second (CORRECT) attempt**
+
+In order for each OpenMP thread to run on its own physical CPU core, each MPI rank should be given 2 physical CPU cores (``-c 2``). Now the OpenMP threads will be mapped to unique hardware threads on separate physical CPU cores.
+
+.. code-block:: bash
+
+    $ export OMP_NUM_THREADS=2
+    $ srun -N1 -n2 -c2 ./hello_mpi_omp | sort
+
+    MPI 000 - OMP 000 - HWT 001 - Node crusher001
+    MPI 000 - OMP 001 - HWT 002 - Node crusher001
+    MPI 001 - OMP 000 - HWT 009 - Node crusher001
+    MPI 001 - OMP 001 - HWT 010 - Node crusher001
+
+Now the output shows that each OpenMP thread ran on (one of the hardware threads of) its own physical CPU core. More specifically (see the Crusher Compute Node diagram), OpenMP thread 000 of MPI rank 000 ran on hardware thread 001 (i.e., physical CPU core 01), OpenMP thread 001 of MPI rank 000 ran on hardware thread 002 (i.e., physical CPU core 02), OpenMP thread 000 of MPI rank 001 ran on hardware thread 009 (i.e., physical CPU core 09), and OpenMP thread 001 of MPI rank 001 ran on hardware thread 010 (i.e., physical CPU core 10) - as intended.
+
+**Third attempt - Using multiple threads per core**
+
+To use both available hardware threads per core, the *job* must be allocated with ``--threads-per-core=2`` (as opposed to only the job step - i.e., ``srun`` command). That value will then be inherited by ``srun`` unless explcitly overridden with ``--threads-per-core=1``.
+
+.. code-block:: bash
+
+    $ salloc -N1 -A <project_id> -t <time> -p <partition> --threads-per-core=2
+
+    $ export OMP_NUM_THREADS=2
+    $ srun -N1 -n2 -c2 ./hello_mpi_omp | sort
+
+    MPI 000 - OMP 000 - HWT 001 - Node crusher001
+    MPI 000 - OMP 001 - HWT 065 - Node crusher001
+    MPI 001 - OMP 000 - HWT 009 - Node crusher001
+    MPI 001 - OMP 001 - HWT 073 - Node crusher001
+
+Comparing this output to the Crusher Compute Node diagram, we see that each pair of OpenMP threads is contained within a single physical core. MPI rank 000 ran on hardware threads 001 and 065 (i.e. physical CPU core 01) and MPI rank 001 ran on hardware threads 009 and 073 (i.e. physical CPU core 09).
+
+.. note::
+
+    There are many different ways users might choose to perform these mappings, so users are encouraged to clone the ``hello_mpi_omp`` program and test whether or not processes and threads are running where intended.
+
+GPU Mapping
+^^^^^^^^^^^
+
+In this sub-section, an MPI+OpenMP+HIP "Hello, World" program (`hello_jobstep <https://code.ornl.gov/olcf/hello_jobstep>`__) will be used to clarify the GPU mappings. Again, Slurm's :ref:`interactive` method was used to request an allocation of 2 compute nodes for these examples: ``salloc -A <project_id> -t 30 -p <parition> -N 2``. The CPU mapping part of this example is very similar to the example used above in the CPU Mapping sub-section, so the focus here will be on the GPU mapping part.
+
+The following ``srun`` options will be used in the examples below. See ``man srun`` for a complete list of options and more information.
+
++------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
+| ``--gpus``                                     | Specify the number of GPUs required for the job (total GPUs across all nodes).                               |
++------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
+| ``--gpus-per-node``                            | Specify the number of GPUs per node required for the job.                                                    |
++------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
+| ``--gpu-bind=closest``                         | Binds each task to the GPU which is on the same NUMA domain as the CPU core the MPI rank is running on.      |
++------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
+| ``--gpu-bind=map_gpu:<list>``                  | Bind tasks to specific GPUs by setting GPU masks on tasks (or ranks) as specified where                      |
+|                                                | ``<list>`` is ``<gpu_id_for_task_0>,<gpu_id_for_task_1>,...``. If the number of tasks (or                    |
+|                                                | ranks) exceeds the number of elements in this list, elements in the list will be reused as                   |
+|                                                | needed starting from the beginning of the list. To simplify support for large task                           |
+|                                                | counts, the lists may follow a map with an asterisk and repetition count. (For example                       |
+|                                                | ``map_gpu:0*4,1*4``)                                                                                         |
++------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
+| ``--ntasks-per-gpu=<ntasks>``                  | Request that there are ntasks tasks invoked for every GPU.                                                   |
++------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
+| ``--distribution=<value>[:<value>][:<value>]`` | Specifies the distribution of MPI ranks across compute nodes, sockets (L3 regions on Crusher), and cores,    |
+|                                                | respectively. The default values are ``block:cyclic:cyclic``                                                 |
++------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
+
+.. note::
+    Due to the unique architecture of Crusher compute nodes and the way that Slurm currently allocates GPUs and CPU cores to job steps, it is suggested that all 8 GPUs on a node are allocated to the job step to ensure that optimal bindings are possible.
+
+.. note::
+    In general, GPU mapping can be accomplished in different ways. For example, an application might map MPI ranks to GPUs programmatically within the code using, say, ``hipSetDevice``. In this case, since all GPUs on a node are available to all MPI ranks on that node by default, there might not be a need to map to GPUs using Slurm (just do it in the code). However, in another application, there might be a reason to make only a subset of GPUs available to the MPI ranks on a node. It is this latter case that the following examples refer to.
+
+Mapping 1 task per GPU
+""""""""""""""""""""""
+
+In the following examples, each MPI rank (and its OpenMP threads) will be mapped to a single GPU.
+
+**Example 0: 1 MPI rank with 1 OpenMP thread and 1 GPU (single-node)**
+
+Somewhat counterintuitively, this common test case is currently among the most difficult. Slurm ignores GPU bindings for nodes with only a single task, so we do not use ``--gpu-bind`` here. We must allocate only a single GPU to ensure that only one GPU is available to the task, and since we get the first GPU available we should bind the task to the CPU closest to the allocated GPU. 
+
+.. code-block:: bash
+
+    $ export OMP_NUM_THREADS=1
+    $ srun -N1 -n1 -c1 --cpu-bind=map_cpu:49 --gpus=1 ./hello_jobstep
+
+    MPI 000 - OMP 000 - HWT 049 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+
+**Example 1: 8 MPI ranks - each with 2 OpenMP threads and 1 GPU (single-node)**
+
+This example launches 8 MPI ranks (``-n8``), each with 2 physical CPU cores (``-c2``) to launch 2 OpenMP threads (``OMP_NUM_THREADS=2``) on. In addition, each MPI rank (and its 2 OpenMP threads) should have access to only 1 GPU. To accomplish the GPU mapping, two new ``srun`` options will be used:
+
+* ``--gpus-per-node`` specifies the number of GPUs required for the job
+* ``--gpu-bind=closest`` binds each task to the GPU which is closest.
+
+.. note::
+    Without these additional flags, all MPI ranks would have access to all GPUs (which is the default behavior).
+
+.. code-block:: bash
+
+    $ export OMP_NUM_THREADS=2
+    $ srun -N1 -n8 -c2 --gpus-per-node=8 --gpu-bind=closest ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 001 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 000 - OMP 001 - HWT 002 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 001 - OMP 000 - HWT 009 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 001 - OMP 001 - HWT 010 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 002 - OMP 000 - HWT 017 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 002 - OMP 001 - HWT 018 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 003 - OMP 000 - HWT 025 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 003 - OMP 001 - HWT 026 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 004 - OMP 000 - HWT 033 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 004 - OMP 001 - HWT 034 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 005 - OMP 000 - HWT 041 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 005 - OMP 001 - HWT 042 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 006 - OMP 000 - HWT 049 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 006 - OMP 001 - HWT 050 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 007 - OMP 000 - HWT 057 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 007 - OMP 001 - HWT 058 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+
+The output from the program contains a lot of information, so let's unpack it. First, there are different IDs associated with the GPUs so it is important to describe them before moving on. ``GPU_ID`` is the node-level (or global) GPU ID, which is labeled as one might expect from looking at the Crusher Node Diagram: 0, 1, 2, 3, 4, 5, 6, 7. ``RT_GPU_ID`` is the HIP runtime GPU ID, which can be though of as each MPI rank's local GPU ID number (with zero-based indexing). So in the output above, each MPI rank has access to only 1 unique GPU - where MPI 000 has access to "global" GPU 4, MPI 001 has access to "global" GPU 5, etc., but all MPI ranks show a HIP runtime GPU ID of 0. The reason is that each MPI rank only "sees" one GPU and so the HIP runtime labels it as "0", even though it might be global GPU ID 0, 1, 2, 3, 4, 5, 6, or 7. The GPU's bus ID is included to definitively show that different GPUs are being used.
+
+Here is a summary of the different GPU IDs reported by the example program:
+
+* ``GPU_ID`` is the node-level (or global) GPU ID read from ``ROCR_VISIBLE_DEVICES``. If this environment variable is not set (either by the user or by Slurm), the value of ``GPU_ID`` will be set to ``N/A`` by this program.
+* ``RT_GPU_ID`` is the HIP runtime GPU ID (as reported from, say ``hipGetDevice``).
+* ``Bus_ID`` is the physical bus ID associated with the GPUs. Comparing the bus IDs is meant to definitively show that different GPUs are being used.
+
+So the job step (i.e., ``srun`` command) used above gave the desired output. Each MPI rank spawned 2 OpenMP threads and had access to a unique GPU. The ``--gpus-per-node=8`` allocated 8 GPUs for node and the ``--gpu-bind=closest`` ensured that the closest GPU to each rank was the one used.
+
+.. note::
+
+    This example shows an important peculiarity of the Crusher nodes; the "closest" GPUs to each MPI rank are not in sequential order. For example, MPI rank 000 and its two OpenMP threads ran on hardware threads 000 and 001. As can be seen in the Crusher node diagram, these two hardware threads reside in the same L3 cache region, and that L3 region is connected via Infinity Fabric (blue line in the diagram) to GPU 4. This is an important distinction that can affect performance if not considered carefully. 
+
+**Example 2: 16 MPI ranks - each with 2 OpenMP threads and 1 GPU (multi-node)**
+
+This example will extend Example 1 to run on 2 nodes. As the output shows, it is a very straightforward exercise of changing the number of nodes to 2 (``-N2``) and the number of MPI ranks to 16 (``-n16``).
+
+.. code-block:: bash
+
+    $ export OMP_NUM_THREADS=2
+    $ srun -N2 -n16 -c2 --gpus-per-node=8 --gpu-bind=closest ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 001 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 000 - OMP 001 - HWT 002 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 001 - OMP 000 - HWT 009 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 001 - OMP 001 - HWT 010 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 002 - OMP 000 - HWT 017 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 002 - OMP 001 - HWT 018 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 003 - OMP 000 - HWT 025 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 003 - OMP 001 - HWT 026 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 004 - OMP 000 - HWT 033 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 004 - OMP 001 - HWT 034 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 005 - OMP 000 - HWT 041 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 005 - OMP 001 - HWT 042 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 006 - OMP 000 - HWT 049 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 006 - OMP 001 - HWT 050 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 007 - OMP 000 - HWT 057 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 007 - OMP 001 - HWT 058 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 008 - OMP 000 - HWT 001 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 008 - OMP 001 - HWT 002 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 009 - OMP 000 - HWT 009 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 009 - OMP 001 - HWT 010 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 010 - OMP 000 - HWT 017 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 010 - OMP 001 - HWT 018 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 011 - OMP 000 - HWT 025 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 011 - OMP 001 - HWT 026 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 012 - OMP 000 - HWT 033 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 012 - OMP 001 - HWT 034 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 013 - OMP 000 - HWT 041 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 013 - OMP 001 - HWT 042 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 014 - OMP 000 - HWT 049 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 014 - OMP 001 - HWT 050 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 015 - OMP 000 - HWT 057 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 015 - OMP 001 - HWT 058 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+
+**Example 3: 8 MPI ranks - each with 2 OpenMP threads and 1 *specific* GPU (single-node)**
+
+This example will be very similar to Example 1, but instead of using ``--gpu-bind=closest`` to map each MPI rank to the closest GPU, ``--gpu-bind=map_gpu`` will be used to map each MPI rank to a *specific* GPU. The ``map_gpu`` option takes a comma-separated list of GPU IDs to specify how the MPI ranks are mapped to GPUs, where the form of the comma-separated list is ``<gpu_id_for_task_0>, <gpu_id_for_task_1>,...``.
+
+.. code:: bash
+
+    $ export OMP_NUM_THREADS=2
+    $ srun -N1 -n8 -c2 --gpus-per-node=8 --gpu-bind=map_gpu:4,5,2,3,6,7,0,1 ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 001 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 000 - OMP 001 - HWT 002 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 001 - OMP 000 - HWT 009 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 001 - OMP 001 - HWT 010 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 002 - OMP 000 - HWT 017 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 002 - OMP 001 - HWT 018 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 003 - OMP 000 - HWT 025 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 003 - OMP 001 - HWT 026 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 004 - OMP 000 - HWT 033 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 004 - OMP 001 - HWT 034 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 005 - OMP 000 - HWT 041 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 005 - OMP 001 - HWT 042 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 006 - OMP 000 - HWT 049 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 006 - OMP 001 - HWT 050 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 007 - OMP 000 - HWT 057 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 007 - OMP 001 - HWT 058 - Node crusher001 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+
+Here, the output is the same as the results from Example 1. This is because the 8 GPU IDs in the comma-separated list happen to specify the GPUs within the same L3 cache region that the MPI ranks are in. So MPI 000 is mapped to GPU 4, MPI 001 is mapped to GPU 5, etc.
+
+While this level of control over mapping MPI ranks to GPUs might be useful for some applications, it is always important to consider the implication of the mapping. For example, if the order of the GPU IDs in the ``map_gpu`` option is reversed, the MPI ranks and the GPUs they are mapped to would be in different L3 cache regions, which could potentially lead to poorer performance.
+
+**Example 4: 16 MPI ranks - each with 2 OpenMP threads and 1 *specific* GPU (multi-node)**
+
+Extending Examples 2 and 3 to run on 2 nodes is also a straightforward exercise by changing the number of nodes to 2 (``-N2``) and the number of MPI ranks to 16 (``-n16``).
+
+.. code:: bash
+
+    $ export OMP_NUM_THREADS=2
+    $ srun -N2 -n16 -c2 --gpus-per-node=8 --gpu-bind=map_gpu:4,5,2,3,6,7,0,1 ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 001 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 000 - OMP 001 - HWT 002 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 001 - OMP 000 - HWT 009 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 001 - OMP 001 - HWT 010 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 002 - OMP 000 - HWT 017 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 002 - OMP 001 - HWT 018 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 003 - OMP 000 - HWT 025 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 003 - OMP 001 - HWT 026 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 004 - OMP 000 - HWT 033 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 004 - OMP 001 - HWT 034 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 005 - OMP 000 - HWT 041 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 005 - OMP 001 - HWT 042 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 006 - OMP 000 - HWT 049 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 006 - OMP 001 - HWT 050 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 007 - OMP 000 - HWT 057 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 007 - OMP 001 - HWT 058 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 008 - OMP 000 - HWT 001 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 008 - OMP 001 - HWT 002 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 009 - OMP 000 - HWT 009 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 009 - OMP 001 - HWT 010 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 010 - OMP 000 - HWT 017 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 010 - OMP 001 - HWT 018 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 011 - OMP 000 - HWT 025 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 011 - OMP 001 - HWT 026 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 012 - OMP 000 - HWT 033 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 012 - OMP 001 - HWT 034 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 013 - OMP 000 - HWT 041 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 013 - OMP 001 - HWT 042 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 014 - OMP 000 - HWT 049 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 014 - OMP 001 - HWT 050 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 015 - OMP 000 - HWT 057 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 015 - OMP 001 - HWT 058 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+
+Mapping multiple MPI ranks to a single GPU
+""""""""""""""""""""""""""""""""""""""""""
+
+In the following examples, 2 MPI ranks will be mapped to 1 GPU. For the sake of brevity, ``OMP_NUM_THREADS`` will be set to ``1``, so ``-c1`` will be used unless otherwise specified.
+
+.. note::
+
+    On AMD's MI250X, multi-process service (MPS) is not needed since multiple MPI ranks per GPU is supported natively.
+
+**Example 5: 16 MPI ranks - where 2 ranks share a GPU (round-robin, single-node)**
+
+This example launches 16 MPI ranks (``-n16``), each with 1 physical CPU core (``-c1``) to launch 1 OpenMP thread (``OMP_NUM_THREADS=1``) on. The MPI ranks will be assigned to GPUs in a round-robin fashion so that each of the 8 GPUs on the node are shared by 2 MPI ranks. To accomplish this GPU mapping, a new ``srun`` options will be used:
+
+* ``--ntasks-per-gpu`` specifies the number of MPI ranks that will share access to a GPU.
+
+.. code:: bash
+
+    $ export OMP_NUM_THREADS=1
+    $ srun -N1 -n16 -c1 --ntasks-per-gpu=2 --gpu-bind=closest ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 001 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 001 - OMP 000 - HWT 009 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 002 - OMP 000 - HWT 017 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 003 - OMP 000 - HWT 025 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 004 - OMP 000 - HWT 033 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 005 - OMP 000 - HWT 041 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 006 - OMP 000 - HWT 049 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 007 - OMP 000 - HWT 057 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 008 - OMP 000 - HWT 002 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 009 - OMP 000 - HWT 010 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 010 - OMP 000 - HWT 018 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 011 - OMP 000 - HWT 026 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 012 - OMP 000 - HWT 034 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 013 - OMP 000 - HWT 042 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 014 - OMP 000 - HWT 050 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 015 - OMP 000 - HWT 058 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+
+The output shows the round-robin (``cyclic``) distribution of MPI ranks to GPUs. In fact, it is a round-robin distribution of MPI ranks *to L3 cache regions* (the default distribution). The GPU mapping is a consequence of where the MPI ranks are distributed; ``--gpu-bind=closest`` simply maps the GPU in an L3 cache region to the MPI ranks in the same L3 region.
+
+**Example 6: 32 MPI ranks - where 2 ranks share a GPU (round-robin, multi-node)**
+
+This example is an extension of Example 5 to run on 2 nodes.
+
+.. code:: bash
+
+    $ export OMP_NUM_THREADS=1
+    $ srun -N2 -n32 -c1 --ntasks-per-gpu=2 --gpu-bind=closest ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 001 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 001 - OMP 000 - HWT 009 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 002 - OMP 000 - HWT 017 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 003 - OMP 000 - HWT 025 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 004 - OMP 000 - HWT 033 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 005 - OMP 000 - HWT 041 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 006 - OMP 000 - HWT 049 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 007 - OMP 000 - HWT 057 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 008 - OMP 000 - HWT 002 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 009 - OMP 000 - HWT 010 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 010 - OMP 000 - HWT 018 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 011 - OMP 000 - HWT 026 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 012 - OMP 000 - HWT 034 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 013 - OMP 000 - HWT 042 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 014 - OMP 000 - HWT 050 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 015 - OMP 000 - HWT 058 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 016 - OMP 000 - HWT 001 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 017 - OMP 000 - HWT 009 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 018 - OMP 000 - HWT 017 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 019 - OMP 000 - HWT 025 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 020 - OMP 000 - HWT 033 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 021 - OMP 000 - HWT 041 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 022 - OMP 000 - HWT 049 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 023 - OMP 000 - HWT 057 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 024 - OMP 000 - HWT 002 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 025 - OMP 000 - HWT 010 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 026 - OMP 000 - HWT 018 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 027 - OMP 000 - HWT 026 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 028 - OMP 000 - HWT 034 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 029 - OMP 000 - HWT 042 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 030 - OMP 000 - HWT 050 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 031 - OMP 000 - HWT 058 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+
+**Example 7: 16 MPI ranks - where 2 ranks share a GPU (packed, single-node)**
+
+This example launches 16 MPI ranks (``-n16``), each with 4 physical CPU cores (``-c4``) to launch 1 OpenMP thread (``OMP_NUM_THREADS=1``) on. Because it is using 4 physical CPU cores per task, core specialization needs to be disabled (``-S 0``). The MPI ranks will be assigned to GPUs in a packed fashion so that each of the 8 GPUs on the node are shared by 2 MPI ranks. Similar to Example 5, ``-ntasks-per-gpu=2`` will be used, but a new ``srun`` flag will be used to change the default round-robin (``cyclic``) distribution of MPI ranks across NUMA domains:
+
+* ``--distribution=<value>[:<value>][:<value>]`` specifies the distribution of MPI ranks across compute nodes, sockets (L3 cache regions on Crusher), and cores, respectively. The default values are ``block:cyclic:cyclic``, which is where the ``cyclic`` assignment comes from in the previous examples.
+
+.. note::
+
+    In the job step for this example, ``--distribution=*:block`` is used, where ``*`` represents the default value of ``block`` for the distribution of MPI ranks across compute nodes and the distribution of MPI ranks across L3 cache regions has been changed to ``block`` from its default value of ``cyclic``.
+
+.. note::
+
+    Because the distribution across L3 cache regions has been changed to a "packed" (``block``) configuration, caution must be taken to ensure MPI ranks end up in the L3 cache regions where the GPUs they intend to be mapped to are located. To accomplish this, the number of physical CPU cores assigned to an MPI rank was increased - in this case to 4. Doing so ensures that only 2 MPI ranks can fit into a single L3 cache region. If the value of ``-c`` was left at ``1``, all 8 MPI ranks would be "packed" into the first L3 region, where the "closest" GPU would be GPU 4 - the only GPU in that L3 region.
+
+    Notice that this is not a workaround like in Example 6, but a requirement due to the ``block`` distribution of MPI ranks across NUMA domains.
+
+.. code:: bash
+
+    $ salloc -N 1 -S 0 ...
+    <job starts>
+    $ export OMP_NUM_THREADS=1
+    $ srun -N1 -n16 -c3 --ntasks-per-gpu=2 --gpu-bind=closest --distribution=*:block ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 002 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 001 - OMP 000 - HWT 006 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 002 - OMP 000 - HWT 010 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 003 - OMP 000 - HWT 014 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 004 - OMP 000 - HWT 016 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 005 - OMP 000 - HWT 021 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 006 - OMP 000 - HWT 027 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 007 - OMP 000 - HWT 031 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 008 - OMP 000 - HWT 034 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 009 - OMP 000 - HWT 037 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 010 - OMP 000 - HWT 042 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 011 - OMP 000 - HWT 045 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 012 - OMP 000 - HWT 049 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 013 - OMP 000 - HWT 053 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 014 - OMP 000 - HWT 057 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 015 - OMP 000 - HWT 061 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+
+The overall effect of using ``--distribution=*:block`` and increasing the number of physical CPU cores available to each MPI rank is to place the first two MPI ranks in the first L3 cache region with GPU 4, the next two MPI ranks in the second L3 cache region with GPU 5, and so on.
+
+**Example 8: 32 MPI ranks - where 2 ranks share a GPU (packed, multi-node)**
+
+This example is an extension of Example 7 to use 2 compute nodes. Again, because it is using 4 physical CPU cores per task, core specialization needs to be disabled (``-S 0``). With the appropriate changes put in place in Example 7, it is a straightforward exercise to change to using 2 nodes (``-N2``) and 32 MPI ranks (``-n32``).
+
+.. code:: bash
+
+    $ export OMP_NUM_THREADS=1
+    $ srun -N2 -n32 -c4 --ntasks-per-gpu=2 --gpu-bind=closest --distribution=*:block ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 001 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 001 - OMP 000 - HWT 005 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 002 - OMP 000 - HWT 009 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 003 - OMP 000 - HWT 014 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 004 - OMP 000 - HWT 017 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 005 - OMP 000 - HWT 020 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 006 - OMP 000 - HWT 025 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 007 - OMP 000 - HWT 029 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 008 - OMP 000 - HWT 033 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 009 - OMP 000 - HWT 037 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 010 - OMP 000 - HWT 042 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 011 - OMP 000 - HWT 045 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 012 - OMP 000 - HWT 049 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 013 - OMP 000 - HWT 054 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 014 - OMP 000 - HWT 058 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 015 - OMP 000 - HWT 063 - Node crusher002 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 016 - OMP 000 - HWT 001 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 017 - OMP 000 - HWT 005 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 4 - Bus_ID d1
+    MPI 018 - OMP 000 - HWT 009 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 019 - OMP 000 - HWT 014 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 5 - Bus_ID d6
+    MPI 020 - OMP 000 - HWT 017 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 021 - OMP 000 - HWT 021 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 022 - OMP 000 - HWT 026 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 023 - OMP 000 - HWT 028 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+    MPI 024 - OMP 000 - HWT 033 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 025 - OMP 000 - HWT 037 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 6 - Bus_ID d9
+    MPI 026 - OMP 000 - HWT 042 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 027 - OMP 000 - HWT 045 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 7 - Bus_ID de
+    MPI 028 - OMP 000 - HWT 049 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 029 - OMP 000 - HWT 052 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 030 - OMP 000 - HWT 059 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 031 - OMP 000 - HWT 061 - Node crusher004 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+
+
+**Example 9: 4 independent and simultaneous job steps in a single allocation**
+
+This example shows how to run multiple job steps simultaneously in a single allocation. The example below demonstrates running 4 independent, single rank MPI executions on a single node, however the example could be extrapolated to more complex invocations using the above examples.
+
+Submission script:
+
+.. code:: bash
+
+    #!/bin/bash
+    #SBATCH -A <projid>
+    #SBATCH -N 1
+    #SBATCH -t 10
+
+    srun -N1 -c1 --gpus-per-task=1 --exact ./hello_jobstep &
+    sleep 1
+    srun -N1 -c1 --gpus-per-task=1 --exact ./hello_jobstep &
+    sleep 1
+    srun -N1 -c1 --gpus-per-task=1 --exact ./hello_jobstep &
+    sleep 1
+    srun -N1 -c1 --gpus-per-task=1 --exact ./hello_jobstep &
+    wait
+
+
+Output:
+
+.. code:: bash
+
+    MPI 000 - OMP 000 - HWT 017 - Node crusher166 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID c9
+    MPI 000 - OMP 000 - HWT 057 - Node crusher166 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID c6
+    MPI 000 - OMP 000 - HWT 049 - Node crusher166 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c1
+    MPI 000 - OMP 000 - HWT 025 - Node crusher166 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID ce
+
+.. note::
+
+   The ``--exact`` parameter is important to avoid the error message ``srun: Job <job id> step creation temporarily disabled, retrying (Requested nodes are busy)``. The ``wait`` command is also critical, or your job script and allocation will immediately end after launching your jobs in the background. The ``sleep`` command is currently required to work around a known issue that causes MPICH ERROR. ``sleep`` will no longer be needed in a future update.
+
+.. note::
+
+   This may result in a sub-optimal alignment of CPU and GPU on the node, as shown in the example output. Unfortunately, at the moment there is not a workaround for this, however improvements are possible in future SLURM updates.
+
+
+
+Multiple GPUs per MPI rank
+""""""""""""""""""""""""""
+
+As mentioned previously, all GPUs are accessible by all MPI ranks by default, so it is possible to *programatically* map any combination of GPUs to MPI ranks. It should be noted however that Cray MPICH does not support GPU-aware MPI for multiple GPUs per rank, so this binding is not suggested.
+
+..
+    However, there is currently no way to use Slurm to map multiple GPUs to a single MPI rank. If this functionality is needed for an application, please submit a ticket by emailing help@olcf.ornl.gov.
+
+
+.. note::
+
+    There are many different ways users might choose to perform these mappings, so users are encouraged to clone the ``hello_jobstep`` program and test whether or not processes and threads are running where intended.
+
+
+NVMe Usage
+----------
+
+Each Crusher compute node has [2x] 1.92 TB NVMe devices (SSDs) with a peak sequential performance of 5500 MB/s (read) and 2000 MB/s (write). To use the NVMe, users must request access during job allocation using the ``-C nvme`` option to ``sbatch``, ``salloc``, or ``srun``. Once the devices have been granted to a job, users can access them at ``/mnt/bb/<userid>``. Users are responsible for moving data to/from the NVMe before/after their jobs. Here is a simple example script:
+
+.. code:: bash
+
+    #!/bin/bash
+    #SBATCH -A <projid>
+    #SBATCH -J nvme_test
+    #SBATCH -o %x-%j.out
+    #SBATCH -t 00:05:00
+    #SBATCH -p batch
+    #SBATCH -N 1
+    #SBATCH -C nvme
+
+    date
+
+    # Change directory to user scratch space (Orion)
+    cd /lustre/orion/<projid>/scratch/<userid>
+
+    echo " "
+    echo "*****ORIGINAL FILE*****"
+    cat test.txt
+    echo "***********************"
+
+    # Move file from Orion to SSD
+    mv test.txt /mnt/bb/<userid>
+
+    # Edit file from compute node
+    srun -n1 hostname >> /mnt/bb/<userid>/test.txt
+
+    # Move file from SSD back to Orion
+    mv /mnt/bb/<userid>/test.txt .
+
+    echo " "
+    echo "*****UPDATED FILE******"
+    cat test.txt
+    echo "***********************"
+
+And here is the output from the script:
+
+.. code:: bash
+
+    $ cat nvme_test-<jobid>.out
+    Fri Oct 8 12:28:18 EDT 2021
+
+    *****ORIGINAL FILE*****
+    This is my file. There are many like it but this one is mine.
+    ***********************
+
+    *****UPDATED FILE******
+    This is my file. There are many like it but this one is mine.
+    crusher025
+    ***********************
+
+
+Tips for Launching at Scale
+---------------------------
+
+SBCAST your executable and libraries
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Slurm contains a utility called ``sbcast``. This program takes a file and broadcasts it to each node's node-local storage (ie, ``/tmp``, NVMe).
+This is useful for sharing large input files, binaries and shared libraries, while reducing the overhead on shared file systems and overhead at startup.
+This is highly recommended at scale if you have multiple shared libraries on Lustre/NFS file systems.
+
+SBCASTing a single file
+"""""""""""""""""""""""
+
+Here is a simple example of a file ``sbcast`` from a user's scratch space on Lustre to each node's NVMe drive:
+
+.. code:: bash
+
+    #!/bin/bash
+    #SBATCH -A <projid>
+    #SBATCH -J sbcast_to_nvme
+    #SBATCH -o %x-%j.out
+    #SBATCH -t 00:05:00
+    #SBATCH -p batch
+    #SBATCH -N 2
+    #SBATCH -C nvme
+
+    date
+
+    # Change directory to user scratch space (Orion)
+    cd /lustre/orion/<projid>/scratch/<userid>
+
+    echo "This is an example file" > test.txt
+    echo
+    echo "*****ORIGINAL FILE*****"
+    cat test.txt
+    echo "***********************"
+
+    # SBCAST file from Orion to NVMe -- NOTE: ``-C nvme`` is required to use the NVMe drive
+    sbcast -pf test.txt /mnt/bb/$USER/test.txt
+    if [ ! "$?" == "0" ]; then
+        # CHECK EXIT CODE. When SBCAST fails, it may leave partial files on the compute nodes, and if you continue to launch srun,
+        # your application may pick up partially complete shared library files, which would give you confusing errors.
+        echo "SBCAST failed!"
+        exit 1
+    fi
+
+    echo
+    echo "*****DISPLAYING FILES ON EACH NODE IN THE ALLOCATION*****"
+    # Check to see if file exists
+    srun -N ${SLURM_NNODES} -n ${SLURM_NNODES} --ntasks-per-node=1 bash -c "echo \"\$(hostname): \$(ls -lh /mnt/bb/$USER/test.txt)\""
+    echo "*********************************************************"
+
+    echo
+    # Showing the file on the current node -- this will be the same on all other nodes in the allocation
+    echo "*****SBCAST FILE ON CURRENT NODE******"
+    cat /mnt/bb/$USER/test.txt
+    echo "**************************************"
+
+
+and here is the output from that script:
+
+.. code:: bash
+
+    Fri 03 Mar 2023 03:43:30 PM EST
+    
+    *****ORIGINAL FILE*****
+    This is an example file
+    ***********************
+
+    *****DISPLAYING FILES ON EACH NODE IN THE ALLOCATION*****
+    crusher001: -rw-r--r-- 1 hagertnl hagertnl 24 Mar  3 15:43 /mnt/bb/hagertnl/test.txt
+    crusher002: -rw-r--r-- 1 hagertnl hagertnl 24 Mar  3 15:43 /mnt/bb/hagertnl/test.txt
+    *********************************************************
+    
+    *****SBCAST FILE ON CURRENT NODE******
+    This is an example file
+    **************************************
+
+
+SBCASTing a binary with libraries stored on shared file systems
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+``sbcast`` also handles binaries and their libraries:
+
+.. code:: bash
+
+    #!/bin/bash
+    #SBATCH -A <projid>
+    #SBATCH -J sbcast_binary_to_nvme
+    #SBATCH -o %x-%j.out
+    #SBATCH -t 00:05:00
+    #SBATCH -p batch
+    #SBATCH -N 2
+    #SBATCH -C nvme
+
+    date
+
+    # Change directory to user scratch space (Orion)
+    cd /lustre/orion/<projid>/scratch/<userid>
+
+    # For this example, I use a HIP-enabled LAMMPS binary, with dependencies to MPI, HIP, and HWLOC
+    exe="lmp"
+
+    echo "*****ldd ./${exe}*****"
+    ldd ./${exe}
+    echo "*************************"
+
+    # SBCAST executable from Orion to NVMe -- NOTE: ``-C nvme`` is needed in SBATCH headers to use the NVMe drive
+    # NOTE: dlopen'd files will NOT be picked up by sbcast
+    # SBCAST automatically excludes several directories: /lib,/usr/lib,/lib64,/usr/lib64,/opt
+    #   - These directories are node-local and are very fast to read from, so SBCASTing them isn't critical
+    #   - see ``$ scontrol show config | grep BcastExclude`` for current list
+    #   - OLCF-provided libraries in ``/sw`` are not on the exclusion list. ``/sw`` is an NFS shared file system
+    #   - To override, add ``--exclude=NONE`` to arguments
+    sbcast --send-libs -pf ${exe} /mnt/bb/$USER/${exe}
+    if [ ! "$?" == "0" ]; then
+        # CHECK EXIT CODE. When SBCAST fails, it may leave partial files on the compute nodes, and if you continue to launch srun,
+        # your application may pick up partially complete shared library files, which would give you confusing errors.
+        echo "SBCAST failed!"
+        exit 1
+    fi
+
+    # Check to see if file exists
+    echo "*****ls -lh /mnt/bb/$USER*****"
+    ls -lh /mnt/bb/$USER/
+    echo "*****ls -lh /mnt/bb/$USER/${exe}_libs*****"
+    ls -lh /mnt/bb/$USER/${exe}_libs
+
+    # SBCAST sends all libraries detected by `ld` (minus any excluded), and stores them in the same directory in each node's node-local storage
+    # Any libraries opened by `dlopen` are NOT sent, since they are not known by the linker at run-time.
+
+    # At minimum: prepend the node-local path to LD_LIBRARY_PATH to pick up the SBCAST libraries
+    # It is also recommended that you **remove** any paths that you don't need, like those that contain the libraries that you just SBCAST'd
+    # Failure to remove may result in unnecessary calls to stat shared file systems
+    export LD_LIBRARY_PATH="/mnt/bb/$USER/${exe}_libs:${LD_LIBRARY_PATH}"
+
+    # If you SBCAST **all** your libraries (ie, `--exclude=NONE`), you may use the following line:
+    #export LD_LIBRARY_PATH="/mnt/bb/$USER/${exe}_libs:$(pkg-config --variable=libdir libfabric)"
+    # Use with caution -- certain libraries may use ``dlopen`` at runtime, and that is NOT covered by sbcast
+    # If you use this option, we recommend you contact OLCF Help Desk for the latest list of additional steps required
+
+    # You may notice that some libraries are still linked from /sw/frontier, even after SBCASTing.
+    # This is because the Spack-build modules use RPATH to find their dependencies.
+    echo "*****ldd /mnt/bb/$USER/${exe}*****"
+    ldd /mnt/bb/$USER/${exe}
+    echo "*************************************"
+
+
+and here is the output from that script:
+
+.. code:: bash
+
+    Tue 28 Mar 2023 05:01:41 PM EDT
+    *****ldd ./lmp*****
+    	linux-vdso.so.1 (0x00007fffeda02000)
+    	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffed5bb000)
+    	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffed398000)
+    	libm.so.6 => /lib64/libm.so.6 (0x00007fffed04d000)
+    	librt.so.1 => /lib64/librt.so.1 (0x00007fffece44000)
+    	libamdhip64.so.4 => /opt/rocm-4.5.2/lib/libamdhip64.so.4 (0x00007fffec052000)
+    	libmpi_cray.so.12 => /opt/cray/pe/lib64/libmpi_cray.so.12 (0x00007fffe96cc000)
+    	libmpi_gtl_hsa.so.0 => /opt/cray/pe/lib64/libmpi_gtl_hsa.so.0 (0x00007fffe9469000)
+    	libhsa-runtime64.so.1 => /opt/rocm-5.3.0/lib/libhsa-runtime64.so.1 (0x00007fffe8fdc000)
+    	libhwloc.so.15 => /sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/hwloc-2.5.0-4p6jkgf5ez6wr27pytkzyptppzpugu3e/lib/libhwloc.so.15 (0x00007fffe8d82000)
+    	libdl.so.2 => /lib64/libdl.so.2 (0x00007fffe8b7e000)
+    	libhipfft.so => /opt/rocm-5.3.0/lib/libhipfft.so (0x00007fffed9d2000)
+    	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffe875b000)
+    	libc.so.6 => /lib64/libc.so.6 (0x00007fffe8366000)
+    	/lib64/ld-linux-x86-64.so.2 (0x00007fffed7da000)
+    	libamd_comgr.so.2 => /opt/rocm-5.3.0/lib/libamd_comgr.so.2 (0x00007fffe06e0000)
+    	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe04d4000)
+    	libfabric.so.1 => /opt/cray/libfabric/1.15.2.0/lib64/libfabric.so.1 (0x00007fffe01e2000)
+    	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffdffd9000)
+    	libpmi.so.0 => /opt/cray/pe/lib64/libpmi.so.0 (0x00007fffdfdd7000)
+    	libpmi2.so.0 => /opt/cray/pe/lib64/libpmi2.so.0 (0x00007fffdfb9e000)
+    	libquadmath.so.0 => /usr/lib64/libquadmath.so.0 (0x00007fffdf959000)
+    	libmodules.so.1 => /opt/cray/pe/lib64/cce/libmodules.so.1 (0x00007fffed9b5000)
+    	libfi.so.1 => /opt/cray/pe/lib64/cce/libfi.so.1 (0x00007fffdf3b4000)
+    	libcraymath.so.1 => /opt/cray/pe/lib64/cce/libcraymath.so.1 (0x00007fffed8ce000)
+    	libf.so.1 => /opt/cray/pe/lib64/cce/libf.so.1 (0x00007fffed83b000)
+    	libu.so.1 => /opt/cray/pe/lib64/cce/libu.so.1 (0x00007fffdf2ab000)
+    	libcsup.so.1 => /opt/cray/pe/lib64/cce/libcsup.so.1 (0x00007fffed832000)
+    	libamdhip64.so.5 => /opt/rocm-5.3.0/lib/libamdhip64.so.5 (0x00007fffdda8a000)
+    	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffdd871000)
+    	libdrm.so.2 => /usr/lib64/libdrm.so.2 (0x00007fffdd65d000)
+    	libdrm_amdgpu.so.1 => /usr/lib64/libdrm_amdgpu.so.1 (0x00007fffdd453000)
+    	libpciaccess.so.0 => /sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/libpciaccess-0.16-6evcvl74myxfxdrddmnsvbc7sgfx6s5j/lib/libpciaccess.so.0 (0x00007fffdd24a000)
+    	libxml2.so.2 => /sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/libxml2-2.9.12-h7fe2yauotu3xit7rsaixaowd3noknur/lib/libxml2.so.2 (0x00007fffdcee6000)
+    	librocfft.so.0 => /opt/rocm-5.3.0/lib/librocfft.so.0 (0x00007fffdca1a000)
+    	libz.so.1 => /lib64/libz.so.1 (0x00007fffdc803000)
+    	libtinfo.so.6 => /lib64/libtinfo.so.6 (0x00007fffdc5d5000)
+    	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffdc3b0000)
+    	libcurl.so.4 => /usr/lib64/libcurl.so.4 (0x00007fffdc311000)
+    	libjson-c.so.3 => /usr/lib64/libjson-c.so.3 (0x00007fffdc101000)
+    	libpals.so.0 => /opt/cray/pe/lib64/libpals.so.0 (0x00007fffdbefc000)
+    	libgfortran.so.5 => /opt/cray/pe/gcc-libs/libgfortran.so.5 (0x00007fffdba50000)
+    	liblzma.so.5 => /sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/xz-5.2.5-zwra4gpckelt5umczowf3jtmeiz3yd7u/lib/liblzma.so.5 (0x00007fffdb82a000)
+    	libiconv.so.2 => /sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/libiconv-1.16-coz5dzhtoeq5unhjirayfn2xftnxk43l/lib/libiconv.so.2 (0x00007fffdb52e000)
+    	librocfft-device-0.so.0 => /opt/rocm-5.3.0/lib/librocfft-device-0.so.0 (0x00007fffa11a0000)
+    	librocfft-device-1.so.0 => /opt/rocm-5.3.0/lib/librocfft-device-1.so.0 (0x00007fff6491b000)
+    	librocfft-device-2.so.0 => /opt/rocm-5.3.0/lib/librocfft-device-2.so.0 (0x00007fff2a828000)
+    	librocfft-device-3.so.0 => /opt/rocm-5.3.0/lib/librocfft-device-3.so.0 (0x00007ffef7eee000)
+    	libnghttp2.so.14 => /usr/lib64/libnghttp2.so.14 (0x00007ffef7cc6000)
+    	libidn2.so.0 => /usr/lib64/libidn2.so.0 (0x00007ffef7aa9000)
+    	libssh.so.4 => /usr/lib64/libssh.so.4 (0x00007ffef783b000)
+    	libpsl.so.5 => /usr/lib64/libpsl.so.5 (0x00007ffef7629000)
+    	libssl.so.1.1 => /usr/lib64/libssl.so.1.1 (0x00007ffef758a000)
+    	libcrypto.so.1.1 => /usr/lib64/libcrypto.so.1.1 (0x00007ffef724a000)
+    	libgssapi_krb5.so.2 => /usr/lib64/libgssapi_krb5.so.2 (0x00007ffef6ff8000)
+    	libldap_r-2.4.so.2 => /usr/lib64/libldap_r-2.4.so.2 (0x00007ffef6da4000)
+    	liblber-2.4.so.2 => /usr/lib64/liblber-2.4.so.2 (0x00007ffef6b95000)
+    	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007ffef6865000)
+    	libbrotlidec.so.1 => /usr/lib64/libbrotlidec.so.1 (0x00007ffef6659000)
+    	libunistring.so.2 => /usr/lib64/libunistring.so.2 (0x00007ffef62d6000)
+    	libjitterentropy.so.3 => /usr/lib64/libjitterentropy.so.3 (0x00007ffef60cf000)
+    	libkrb5.so.3 => /usr/lib64/libkrb5.so.3 (0x00007ffef5df6000)
+    	libk5crypto.so.3 => /usr/lib64/libk5crypto.so.3 (0x00007ffef5bde000)
+    	libcom_err.so.2 => /lib64/libcom_err.so.2 (0x00007ffef59da000)
+    	libkrb5support.so.0 => /usr/lib64/libkrb5support.so.0 (0x00007ffef57cb000)
+    	libresolv.so.2 => /lib64/libresolv.so.2 (0x00007ffef55b3000)
+    	libsasl2.so.3 => /usr/lib64/libsasl2.so.3 (0x00007ffef5396000)
+    	libbrotlicommon.so.1 => /usr/lib64/libbrotlicommon.so.1 (0x00007ffef5175000)
+    	libkeyutils.so.1 => /usr/lib64/libkeyutils.so.1 (0x00007ffef4f70000)
+    	libselinux.so.1 => /lib64/libselinux.so.1 (0x00007ffef4d47000)
+    	libpcre.so.1 => /usr/lib64/libpcre.so.1 (0x00007ffef4abe000)
+    *************************
+    *****ls -lh /mnt/bb/hagertnl*****
+    total 236M
+    -rwxr-xr-x 1 hagertnl hagertnl 236M Mar 28 17:01 lmp
+    drwx------ 2 hagertnl hagertnl  114 Mar 28 17:01 lmp_libs
+    *****ls -lh /mnt/bb/hagertnl/lmp_libs*****
+    total 9.2M
+    -rwxr-xr-x 1 hagertnl hagertnl 1.6M Oct  6  2021 libhwloc.so.15
+    -rwxr-xr-x 1 hagertnl hagertnl 1.6M Oct  6  2021 libiconv.so.2
+    -rwxr-xr-x 1 hagertnl hagertnl 783K Oct  6  2021 liblzma.so.5
+    -rwxr-xr-x 1 hagertnl hagertnl 149K Oct  6  2021 libpciaccess.so.0
+    -rwxr-xr-x 1 hagertnl hagertnl 5.2M Oct  6  2021 libxml2.so.2
+    *****ldd /mnt/bb/hagertnl/lmp*****
+    	linux-vdso.so.1 (0x00007fffeda02000)
+    	libgcc_s.so.1 => /lib64/libgcc_s.so.1 (0x00007fffed5bb000)
+    	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007fffed398000)
+    	libm.so.6 => /lib64/libm.so.6 (0x00007fffed04d000)
+    	librt.so.1 => /lib64/librt.so.1 (0x00007fffece44000)
+    	libamdhip64.so.4 => /opt/rocm-4.5.2/lib/libamdhip64.so.4 (0x00007fffec052000)
+    	libmpi_cray.so.12 => /opt/cray/pe/lib64/libmpi_cray.so.12 (0x00007fffe96cc000)
+    	libmpi_gtl_hsa.so.0 => /opt/cray/pe/lib64/libmpi_gtl_hsa.so.0 (0x00007fffe9469000)
+    	libhsa-runtime64.so.1 => /opt/rocm-5.3.0/lib/libhsa-runtime64.so.1 (0x00007fffe8fdc000)
+    	libhwloc.so.15 => /mnt/bb/hagertnl/lmp_libs/libhwloc.so.15 (0x00007fffe8d82000)
+    	libdl.so.2 => /lib64/libdl.so.2 (0x00007fffe8b7e000)
+    	libhipfft.so => /opt/rocm-5.3.0/lib/libhipfft.so (0x00007fffed9d2000)
+    	libstdc++.so.6 => /usr/lib64/libstdc++.so.6 (0x00007fffe875b000)
+    	libc.so.6 => /lib64/libc.so.6 (0x00007fffe8366000)
+    	/lib64/ld-linux-x86-64.so.2 (0x00007fffed7da000)
+    	libamd_comgr.so.2 => /opt/rocm-5.3.0/lib/libamd_comgr.so.2 (0x00007fffe06e0000)
+    	libnuma.so.1 => /usr/lib64/libnuma.so.1 (0x00007fffe04d4000)
+    	libfabric.so.1 => /opt/cray/libfabric/1.15.2.0/lib64/libfabric.so.1 (0x00007fffe01e2000)
+    	libatomic.so.1 => /usr/lib64/libatomic.so.1 (0x00007fffdffd9000)
+    	libpmi.so.0 => /opt/cray/pe/lib64/libpmi.so.0 (0x00007fffdfdd7000)
+    	libpmi2.so.0 => /opt/cray/pe/lib64/libpmi2.so.0 (0x00007fffdfb9e000)
+    	libquadmath.so.0 => /usr/lib64/libquadmath.so.0 (0x00007fffdf959000)
+    	libmodules.so.1 => /opt/cray/pe/lib64/cce/libmodules.so.1 (0x00007fffed9b5000)
+    	libfi.so.1 => /opt/cray/pe/lib64/cce/libfi.so.1 (0x00007fffdf3b4000)
+    	libcraymath.so.1 => /opt/cray/pe/lib64/cce/libcraymath.so.1 (0x00007fffed8ce000)
+    	libf.so.1 => /opt/cray/pe/lib64/cce/libf.so.1 (0x00007fffed83b000)
+    	libu.so.1 => /opt/cray/pe/lib64/cce/libu.so.1 (0x00007fffdf2ab000)
+    	libcsup.so.1 => /opt/cray/pe/lib64/cce/libcsup.so.1 (0x00007fffed832000)
+    	libamdhip64.so.5 => /opt/rocm-5.3.0/lib/libamdhip64.so.5 (0x00007fffdda8a000)
+    	libelf.so.1 => /usr/lib64/libelf.so.1 (0x00007fffdd871000)
+    	libdrm.so.2 => /usr/lib64/libdrm.so.2 (0x00007fffdd65d000)
+    	libdrm_amdgpu.so.1 => /usr/lib64/libdrm_amdgpu.so.1 (0x00007fffdd453000)
+    	libpciaccess.so.0 => /sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/libpciaccess-0.16-6evcvl74myxfxdrddmnsvbc7sgfx6s5j/lib/libpciaccess.so.0 (0x00007fffdd24a000)
+    	libxml2.so.2 => /sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/libxml2-2.9.12-h7fe2yauotu3xit7rsaixaowd3noknur/lib/libxml2.so.2 (0x00007fffdcee6000)
+    	librocfft.so.0 => /opt/rocm-5.3.0/lib/librocfft.so.0 (0x00007fffdca1a000)
+    	libz.so.1 => /lib64/libz.so.1 (0x00007fffdc803000)
+    	libtinfo.so.6 => /lib64/libtinfo.so.6 (0x00007fffdc5d5000)
+    	libcxi.so.1 => /usr/lib64/libcxi.so.1 (0x00007fffdc3b0000)
+    	libcurl.so.4 => /usr/lib64/libcurl.so.4 (0x00007fffdc311000)
+    	libjson-c.so.3 => /usr/lib64/libjson-c.so.3 (0x00007fffdc101000)
+    	libpals.so.0 => /opt/cray/pe/lib64/libpals.so.0 (0x00007fffdbefc000)
+    	libgfortran.so.5 => /opt/cray/pe/gcc-libs/libgfortran.so.5 (0x00007fffdba50000)
+    	liblzma.so.5 => /sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/xz-5.2.5-zwra4gpckelt5umczowf3jtmeiz3yd7u/lib/liblzma.so.5 (0x00007fffdb82a000)
+    	libiconv.so.2 => /sw/crusher/spack-envs/base/opt/linux-sles15-x86_64/gcc-7.5.0/libiconv-1.16-coz5dzhtoeq5unhjirayfn2xftnxk43l/lib/libiconv.so.2 (0x00007fffdb52e000)
+    	librocfft-device-0.so.0 => /opt/rocm-5.3.0/lib/librocfft-device-0.so.0 (0x00007fffa11a0000)
+    	librocfft-device-1.so.0 => /opt/rocm-5.3.0/lib/librocfft-device-1.so.0 (0x00007fff6491b000)
+    	librocfft-device-2.so.0 => /opt/rocm-5.3.0/lib/librocfft-device-2.so.0 (0x00007fff2a828000)
+    	librocfft-device-3.so.0 => /opt/rocm-5.3.0/lib/librocfft-device-3.so.0 (0x00007ffef7eee000)
+    	libnghttp2.so.14 => /usr/lib64/libnghttp2.so.14 (0x00007ffef7cc6000)
+    	libidn2.so.0 => /usr/lib64/libidn2.so.0 (0x00007ffef7aa9000)
+    	libssh.so.4 => /usr/lib64/libssh.so.4 (0x00007ffef783b000)
+    	libpsl.so.5 => /usr/lib64/libpsl.so.5 (0x00007ffef7629000)
+    	libssl.so.1.1 => /usr/lib64/libssl.so.1.1 (0x00007ffef758a000)
+    	libcrypto.so.1.1 => /usr/lib64/libcrypto.so.1.1 (0x00007ffef724a000)
+    	libgssapi_krb5.so.2 => /usr/lib64/libgssapi_krb5.so.2 (0x00007ffef6ff8000)
+    	libldap_r-2.4.so.2 => /usr/lib64/libldap_r-2.4.so.2 (0x00007ffef6da4000)
+    	liblber-2.4.so.2 => /usr/lib64/liblber-2.4.so.2 (0x00007ffef6b95000)
+    	libzstd.so.1 => /usr/lib64/libzstd.so.1 (0x00007ffef6865000)
+    	libbrotlidec.so.1 => /usr/lib64/libbrotlidec.so.1 (0x00007ffef6659000)
+    	libunistring.so.2 => /usr/lib64/libunistring.so.2 (0x00007ffef62d6000)
+    	libjitterentropy.so.3 => /usr/lib64/libjitterentropy.so.3 (0x00007ffef60cf000)
+    	libkrb5.so.3 => /usr/lib64/libkrb5.so.3 (0x00007ffef5df6000)
+    	libk5crypto.so.3 => /usr/lib64/libk5crypto.so.3 (0x00007ffef5bde000)
+    	libcom_err.so.2 => /lib64/libcom_err.so.2 (0x00007ffef59da000)
+    	libkrb5support.so.0 => /usr/lib64/libkrb5support.so.0 (0x00007ffef57cb000)
+    	libresolv.so.2 => /lib64/libresolv.so.2 (0x00007ffef55b3000)
+    	libsasl2.so.3 => /usr/lib64/libsasl2.so.3 (0x00007ffef5396000)
+    	libbrotlicommon.so.1 => /usr/lib64/libbrotlicommon.so.1 (0x00007ffef5175000)
+    	libkeyutils.so.1 => /usr/lib64/libkeyutils.so.1 (0x00007ffef4f70000)
+    	libselinux.so.1 => /lib64/libselinux.so.1 (0x00007ffef4d47000)
+    	libpcre.so.1 => /usr/lib64/libpcre.so.1 (0x00007ffef4abe000)
+    *************************************
+
+Notice that the libraries are sent to the ``${exe}_libs`` directory in the same prefix as the executable.
+Once libraries are here, you cannot tell where they came from, so consider doing an ``ldd`` of your executable prior to ``sbcast``.
+
+Alternative: SBCASTing a binary with all libraries
+""""""""""""""""""""""""""""""""""""""""""""""""""
+
+As mentioned above, you can use ``--exclude=NONE`` on ``sbcast`` to send all libraries along with the binary.
+Using ``--exclude=NONE`` requires more effort but substantially simplifies the linker configuration at run-time.
+A job script for the previous example, modified for sending all libraries is shown below.
+
+.. code:: bash
+
+    #!/bin/bash
+    #SBATCH -A <projid>
+    #SBATCH -J sbcast_binary_to_nvme
+    #SBATCH -o %x-%j.out
+    #SBATCH -t 00:05:00
+    #SBATCH -p batch
+    #SBATCH -N 2
+    #SBATCH -C nvme
+
+    date
+
+    # Change directory to user scratch space (Orion)
+    cd /lustre/orion/<projid>/scratch/<userid>
+
+    # For this example, I use a HIP-enabled LAMMPS binary, with dependencies to MPI, HIP, and HWLOC
+    exe="lmp"
+
+    echo "*****ldd ./${exe}*****"
+    ldd ./${exe}
+    echo "*************************"
+
+    # SBCAST executable from Orion to NVMe -- NOTE: ``-C nvme`` is needed in SBATCH headers to use the NVMe drive
+    # NOTE: dlopen'd files will NOT be picked up by sbcast
+    sbcast --send-libs --exclude=NONE -pf ${exe} /mnt/bb/$USER/${exe}
+    if [ ! "$?" == "0" ]; then
+        # CHECK EXIT CODE. When SBCAST fails, it may leave partial files on the compute nodes, and if you continue to launch srun,
+        # your application may pick up partially complete shared library files, which would give you confusing errors.
+        echo "SBCAST failed!"
+        exit 1
+    fi
+
+    # Check to see if file exists
+    echo "*****ls -lh /mnt/bb/$USER*****"
+    ls -lh /mnt/bb/$USER/
+    echo "*****ls -lh /mnt/bb/$USER/${exe}_libs*****"
+    ls -lh /mnt/bb/$USER/${exe}_libs
+
+    # SBCAST sends all libraries detected by `ld` (minus any excluded), and stores them in the same directory in each node's node-local storage
+    # Any libraries opened by `dlopen` are NOT sent, since they are not known by the linker at run-time.
+
+    # All required libraries now reside in /mnt/bb/$USER/${exe}_libs
+    export LD_LIBRARY_PATH="/mnt/bb/$USER/${exe}_libs"
+
+    # libfabric dlopen's several libraries:
+    export LD_LIBRARY_PATH="${LD_LIBRARY_PATH}:$(pkg-config --variable=libdir libfabric)"
+
+    # cray-mpich dlopen's libhsa-runtime64.so and libamdhip64.so (non-versioned), so symlink on each node:
+    srun -N ${SLURM_NNODES} -n ${SLURM_NNODES} --ntasks-per-node=1 --label -D /mnt/bb/$USER/${exe}_libs \
+        bash -c "if [ -f libhsa-runtime64.so.1 ]; then ln -s libhsa-runtime64.so.1 libhsa-runtime64.so; fi;
+        if [ -f libamdhip64.so.5 ]; then ln -s libamdhip64.so.5 libamdhip64.so; fi"
+
+    # RocBLAS has over 1,000 device libraries that may be `dlopen`'d by RocBLAS during a run.
+    # It's impractical to SBCAST all of these, so you can set this path instead, if you use RocBLAS:
+    #export ROCBLAS_TENSILE_LIBPATH=${ROCM_PATH}/lib/rocblas/library
+
+    # You may notice that some libraries are still linked from /sw/crusher, even after SBCASTing.
+    # This is because the Spack-build modules use RPATH to find their dependencies. This behavior cannot be changed.
+    echo "*****ldd /mnt/bb/$USER/${exe}*****"
+    ldd /mnt/bb/$USER/${exe}
+    echo "*************************************"
+
+
+Some libraries still resolved to paths outside of ``/mnt/bb``, and the reason for that is that the executable may have several paths in ``RPATH``.
+
+----
+
+Profiling Applications
+======================
+
+Getting Started with the HPE Performance Analysis Tools (PAT)
+-------------------------------------------------------------------
+
+The Performance Analysis Tools (PAT), formerly CrayPAT, are a suite of utilities that enable users to capture and analyze performance data generated during program execution. These tools provide an integrated infrastructure for measurement, analysis, and visualization of computation, communication, I/O, and memory utilization to help users optimize programs for faster execution and more efficient computing resource usage.
+
+There are three programming interfaces available: (1) ``Perftools-lite``, (2) ``Perftools``, and (3) ``Perftools-preload``.
+
+Below are two examples that generate an instrumented executable using ``Perftools``, which is an advanced interface that provides full-featured data collection and analysis capability, including full traces with timeline displays.
+
+The first example generates an instrumented executable using a ``PrgEnv-amd`` build:
+
+.. code:: bash
+
+    module load PrgEnv-amd
+    module load craype-accel-amd-gfx90a
+    module load rocm
+    module load perftools
+
+    export PATH="${PATH}:${ROCM_PATH}/llvm/bin"
+    export CXX='CC -x hip'
+    export CXXFLAGS='-ggdb -O3 -std=c++17 –Wall'
+    export LD='CC'
+    export LDFLAGS="${CXXFLAGS} -L${ROCM_PATH}/lib"
+    export LIBS='-lamdhip64'
+
+    make clean
+    make
+
+    pat_build -g hip,io,mpi -w -f <executable>
+
+The second example generates an instrumened executable using a ``hipcc`` build:
+
+.. code:: bash
+
+    module load perftools
+    module load craype-accel-amd-gfx90a
+    module load rocm
+    
+    export CXX='hipcc'
+    export CXXFLAGS="$(pat_opts include hipcc) \
+      $(pat_opts pre_compile hipcc) -g -O3 -std=c++17 -Wall \
+      --offload-arch=gfx90a -I${CRAY_MPICH_DIR}/include \
+      $(pat_opts post_compile hipcc)"
+    export LD='hipcc'
+    export LDFLAGS="$(pat_opts pre_link hipcc) ${CXXFLAGS} \
+      -L${CRAY_MPICH_DIR}/lib ${PE_MPICH_GTL_DIR_amd_gfx908}"
+    export LIBS="-lmpi ${PE_MPICH_GTL_LIBS_amd_gfx908} \
+      $(pat_opts post_link hipcc)"
+    
+    make clean
+    make
+    
+    pat_build -g hip,io,mpi -w -f <executable>
+
+The ``pat_build`` command in the above examples generates an instrumented executable with ``+pat`` appended to the executable name (e.g., ``hello_jobstep+pat``).
+
+When run, the instrumented executable will trace HIP, I/O, MPI, and all user functions and generate a folder of results (e.g., ``hello_jobstep+pat+39545-2t``).
+
+To analyze these results, use the ``pat_report`` command, e.g.:
+
+.. code:: bash
+
+    pat_report hello_jobstep+pat+39545-2t
+
+The resulting report includes profiles of functions, profiles of maximum function times, details on load imbalance, details on program energy and power usages, details on memory high water mark, and more.
+
+More detailed information on the HPE Performance Analysis Tools can be found in the `HPE Performance Analysis Tools User Guide <https://support.hpe.com/hpesc/public/docDisplay?docLocale=en_US&docId=a00123563en_us>`__.
+
+.. note::
+
+    When using ``perftools-lite-gpu``, there is a known issue causing ``ld.lld`` not to be found. A workaround this issue can be found `here <https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-513-error-with-perftools-lite-gpu>`__.
+
+Getting Started with HPCToolkit
+-------------------------------
+
+HPCToolkit is an integrated suite of tools for measurement and analysis of program performance on computers ranging from multicore desktop systems to the nation's largest supercomputers. HPCToolkit provides accurate measurements of a program's work, resource consumption, and inefficiency, correlates these metrics with the program's source code, works with multilingual, fully optimized binaries, has very low measurement overhead, and scales to large parallel systems. HPCToolkit's measurements provide support for analyzing a program execution cost, inefficiency, and scaling characteristics both within and across nodes of a parallel system.
+
+Programming models supported by HPCToolkit include MPI, OpenMP, OpenACC, CUDA, OpenCL, DPC++, HIP, RAJA, Kokkos, and others.
+
+Below is an example that generates a profile and loads the results in their GUI-based viewer.
+
+.. code:: bash
+
+    module use /gpfs/alpine/csc322/world-shared/modulefiles/x86_64 
+    module load hpctoolkit 
+    
+    # 1. Profile and trace an application using CPU time and GPU performance counters 
+    srun <srun_options> hpcrun -o <measurement_dir> -t -e CPUTIME -e gpu=amd <application> 
+
+    # 2. Analyze the binary of executables and its dependent libraries 
+    hpcstruct <measurement_dir> 
+
+    # 3. Combine measurements with program structure information and generate a database 
+    hpcprof -o <database_dir> <measurement_dir> 
+
+    # 4. Understand performance issues by analyzing profiles and traces with the GUI 
+    hpcviewer <database_dir> 
+
+More detailed information on HPCToolkit can be found in the `HPCToolkit User's Manual <http://hpctoolkit.org/manual/HPCToolkit-users-manual.pdf>`__.
+
+.. note::
+
+    HPCToolkit does not require a recompile to profile the code. It is recommended to use the -g optimization flag for attribution to source lines.
+
+Getting Started with the ROCm Profiler
+--------------------------------------
+
+``rocprof`` gathers metrics on kernels run on AMD GPU architectures. The profiler works for HIP kernels, as well as offloaded kernels from OpenMP target offloading, OpenCL, and abstraction layers such as Kokkos.
+For a simple view of kernels being run, ``rocprof --stats --timestamp on`` is a great place to start.
+With the ``--stats`` option enabled, ``rocprof`` will generate a file that is named ``results.stats.csv`` by default, but named ``<output>.stats.csv`` if the ``-o`` flag is supplied.
+This file will list all kernels being run, the number of times they are run, the total duration and the average duration (in nanoseconds) of the kernel, and the GPU usage percentage.
+More detailed infromation on ``rocprof`` profiling modes can be found at `ROCm Profiler <https://rocmdocs.amd.com/en/latest/ROCm_Tools/ROCm-Tools.html>`__ documentation.
+
+.. note::
+
+    If you are using ``sbcast``, you need to explicitly ``sbcast`` the AQL profiling library found in ``${ROCM_PATH}/hsa-amd-aqlprofile/lib/libhsa-amd-aqlprofile64.so``.
+    A symbolic link to this library can also be found in ``${ROCM_PATH}/lib``.
+    Alternatively, you may leave ``${ROCM_PATH}/lib`` in your ``LD_LIBRARY_PATH``.
+
+
+Roofline Profiling with the ROCm Profiler
+-----------------------------------------
+The `Roofline <https://docs.nersc.gov/tools/performance/roofline/>`__ performance model is an increasingly popular way to demonstrate and understand application performance.
+This section documents how to construct a simple roofline model for a single kernel using ``rocprof``.
+This roofline model is designed to be comparable to rooflines constructed by NVIDIA's `NSight Compute <https://developer.nvidia.com/blog/accelerating-hpc-applications-with-nsight-compute-roofline-analysis/>`__.
+A roofline model plots the achieved performance (in floating-point operations per second, FLOPS/s) as a function of arithmetic (or operational) intensity (in FLOPS per Byte).
+The model detailed here calculates the bytes moved as they move to and from the GPU's HBM.
+
+.. note::
+
+    Integer instructions and cache levels are currently not documented here.
+
+To get started, you will need to make an input file for ``rocprof``, to be passed in through ``rocprof -i <input_file> --timestamp on -o my_output.csv <my_exe>``.
+Below is an example, and contains the information needed to roofline profile GPU 0, as seen by each rank:
+
+.. code::
+
+    pmc : TCC_EA_RDREQ_32B_sum TCC_EA_RDREQ_sum TCC_EA_WRREQ_sum TCC_EA_WRREQ_64B_sum SQ_INSTS_VALU_ADD_F16 SQ_INSTS_VALU_MUL_F16 SQ_INSTS_VALU_FMA_F16 SQ_INSTS_VALU_TRANS_F16 SQ_INSTS_VALU_ADD_F32 SQ_INSTS_VALU_MUL_F32 SQ_INSTS_VALU_FMA_F32 SQ_INSTS_VALU_TRANS_F32
+    pmc : SQ_INSTS_VALU_ADD_F64 SQ_INSTS_VALU_MUL_F64 SQ_INSTS_VALU_FMA_F64 SQ_INSTS_VALU_TRANS_F64 SQ_INSTS_VALU_MFMA_MOPS_F16 SQ_INSTS_VALU_MFMA_MOPS_BF16 SQ_INSTS_VALU_MFMA_MOPS_F32 SQ_INSTS_VALU_MFMA_MOPS_F64
+    gpu: 0
+
+
+.. note::
+
+    In an application with more than one kernel, you should strongly consider filtering by kernel name by adding a line like: ``kernel: <kernel_name>`` to the ``rocprof`` input file.
+
+
+This provides the minimum set of metrics used to construct a roofline model, in the minimum number of passes.
+Each line that begins with ``pmc`` indicates that the application will be re-run, and the metrics in that line will be collected.
+``rocprof`` can collect up to 8 counters from each block (``SQ``, ``TCC``) in each application re-run.
+To gather metrics across multiple MPI ranks, you will need to use a command that redirects the output of rocprof to a unique file for each task.
+For example:
+
+.. code:: bash
+
+    srun -N 2 -n 16 --ntasks-per-node=8 --gpus-per-node=8 --gpu-bind=closest bash -c 'rocprof -o ${SLURM_JOBID}_${SLURM_PROCID}.csv -i <input_file> --timestamp on <exe>'
+
+
+.. note::
+
+    The ``gpu:`` filter in the ``rocprof`` input file identifies GPUs by the number the MPI rank would see them as. In the ``srun`` example above,
+    each MPI rank only has 1 GPU, so each rank sees its GPU as GPU 0.
+
+
+Theoretical Roofline
+^^^^^^^^^^^^^^^^^^^^
+
+The theoretical (not attainable) peak roofline constructs a theoretical maximum performance for each operational intensity.
+
+.. note::
+
+    ``theoretical`` peak is determined by the hardware specifications and is not attainable in practice. ``attaiable`` peak is the performance as measured by
+    in-situ microbenchmarks designed to best utilize the hardware. ``achieved`` performance is what the profiled application actually achieves.
+
+
+The theoretical roofline can be constructed as:
+
+.. math::
+
+    FLOPS_{peak} = minimum(ArithmeticIntensity * BW_{HBM}, TheoreticalFLOPS)
+
+
+On Crusher, the memory bandwidth for HBM is 1.6 TB/s, and the theoretical peak floating-point FLOPS/s when using vector registers is calculated by:
+
+.. math::
+
+    TheoreticalFLOPS = 128 FLOP/cycle/CU * 110 CU * 1700000000 cycles/second = 23.9 TFLOP/s
+
+
+However, when using MFMA instructions, the theoretical peak floating-point FLOPS/s is calculated by:
+
+.. math::
+
+    TheoreticalFLOPS = flop\_per\_cycle(precision) FLOP/cycle/CU * 110 CU * 1700000000 cycles/second
+
+
+where ``flop_per_cycle(precision)`` is the published floating-point operations per clock cycle, per compute unit.
+Those values are:
+
++------------+-----------------+
+| Data Type  | Flops/Clock/CU  |
++============+=================+
+| FP64       | 256             |
++------------+-----------------+
+| FP32       | 256             |
++------------+-----------------+
+| FP16       | 1024            |
++------------+-----------------+
+| BF16       | 1024            |
++------------+-----------------+
+| INT8       | 1024            |
++------------+-----------------+
+
+
+.. note::
+    Attainable peak rooflines are constructed using microbenchmarks, and are not currently discussed here.
+    Attainable rooflines consider the limitations of cooling and power consumption and are more representative of what an application can achieve.
+
+
+Achieved FLOPS/s
+^^^^^^^^^^^^^^^^
+
+We calculate the achieved performance at the desired level (here, double-precision floating point, FP64), by summing each metric count and weighting the FMA metric by 2, since a fused multiply-add is considered 2 floating point operations.
+Also note that these ``SQ_INSTS_VALU_<ADD,MUL,TRANS>`` metrics are reported as per-simd, so we mutliply by the wavefront size as well.
+The ``SQ_INSTS_VALU_MFMA_MOPS_*`` instructions should be multiplied by the ``Flops/Cycle/CU`` value listed above.
+We use this equation to calculate the number of double-precision FLOPS:
+
+.. math::
+
+    FP64\_FLOPS =   64  *&(SQ\_INSTS\_VALU\_ADD\_F64         \\\\
+                         &+ SQ\_INSTS\_VALU\_MUL\_F64       \\\\
+                         &+ SQ\_INSTS\_VALU\_TRANS\_F64     \\\\
+                         &+ 2 * SQ\_INSTS\_VALU\_FMA\_F64)  \\\\
+                  + 256 *&(SQ\_INSTS\_VALU\_MFMA\_MOPS\_F64)
+
+
+When ``SQ_INSTS_VALU_MFMA_MOPS_*_F64`` instructions are used, then 47.8 TF/s is considered the theoretical maximum FLOPS/s.
+If only ``SQ_INSTS_VALU_<ADD,MUL,TRANS>`` are found, then 23.9 TF/s is the theoretical maximum FLOPS/s.
+Then, we divide the number of FLOPS by the elapsed time of the kernel to find FLOPS per second.
+This is found from subtracting the ``rocprof`` metrics ``EndNs`` by ``BeginNs``, provided by ``--timestamp on``, then converting from nanoseconds to seconds by dividing by 1,000,000,000 (power(10,9)).
+
+
+
+Calculating for all precisions
+""""""""""""""""""""""""""""""
+
+The above formula can be adapted to compute the total FLOPS across all floating-point precisions (``INT`` excluded).
+
+.. math::
+
+    TOTAL\_FLOPS =   64  *&(SQ\_INSTS\_VALU\_ADD\_F16         \\\\
+                         &+ SQ\_INSTS\_VALU\_MUL\_F16       \\\\
+                         &+ SQ\_INSTS\_VALU\_TRANS\_F16     \\\\
+                         &+ 2 * SQ\_INSTS\_VALU\_FMA\_F16)  \\\\
+                  + 64  *&(SQ\_INSTS\_VALU\_ADD\_F32         \\\\
+                         &+ SQ\_INSTS\_VALU\_MUL\_F32       \\\\
+                         &+ SQ\_INSTS\_VALU\_TRANS\_F32     \\\\
+                         &+ 2 * SQ\_INSTS\_VALU\_FMA\_F32)  \\\\
+                  + 64  *&(SQ\_INSTS\_VALU\_ADD\_F64         \\\\
+                         &+ SQ\_INSTS\_VALU\_MUL\_F64       \\\\
+                         &+ SQ\_INSTS\_VALU\_TRANS\_F64     \\\\
+                         &+ 2 * SQ\_INSTS\_VALU\_FMA\_F64)  \\\\
+                  + 1024 &*(SQ\_INSTS\_VALU\_MFMA\_MOPS\_F16) \\\\
+                  + 1024 &*(SQ\_INSTS\_VALU\_MFMA\_MOPS\_BF16) \\\\
+                  + 256 *&(SQ\_INSTS\_VALU\_MFMA\_MOPS\_F32) \\\\
+                  + 256 *&(SQ\_INSTS\_VALU\_MFMA\_MOPS\_F64) \\\\
+
+
+Arithmetic Intensity
+^^^^^^^^^^^^^^^^^^^^
+
+Arithmetic intensity calculates the ratio of FLOPS to bytes moved between HBM and L2 cache.
+We calculated FLOPS above (FP64_FLOPS).
+We can calculate the number of bytes moved using the ``rocprof`` metrics ``TCC_EA_WRREQ_64B``, ``TCC_EA_WRREQ_sum``, ``TCC_EA_RDREQ_32B``, and ``TCC_EA_RDREQ_sum``.
+``TCC`` refers to the L2 cache, and ``EA`` is the interface between L2 and HBM.
+``WRREQ`` and ``RDREQ`` are write-requests and read-requests, respectively.
+Each of these requests is either 32 bytes or 64 bytes.
+So we calculate the number of bytes traveling over the EA interface as:
+
+.. math::
+
+    BytesMoved = BytesWritten + BytesRead
+
+where
+
+.. math::
+
+    BytesWritten = 64 * TCC\_EA\_WRREQ\_64B\_sum + 32 * (TCC\_EA\_WRREQ\_sum - TCC\_EA\_WRREQ\_64B\_sum)
+
+.. math::
+
+    BytesRead = 32 * TCC\_EA\_RDREQ\_32B\_sum + 64 * (TCC\_EA\_RDREQ\_sum - TCC\_EA\_RDREQ\_32B\_sum)
+
+
+Omnitrace
+---------
+
+OLCF provides installations of AMD's `Omnitrace <https://github.com/AMDResearch/omnitrace>`_ profiling tools on Frontier.
+AMD provides documentation on the usage of Omnitrace at `<https://amdresearch.github.io/omnitrace/>`_.
+This section details the installation and common pitfalls of the ``omnitrace`` module on Frontier.
+
+Unlike ``omniperf``, the ``omnitrace`` module only relies on a ROCm module (``amd``, ``amd-mixed``, or ``rocm``).
+A ROCm module must be loaded before being able to do view or load the ``omnitrace`` module.
+As a rule of thumb, always load the ``omnitrace`` module last (especially after you load a ROCm module like ``amd``, ``rocm``, ``amd-mixed``).
+If you load a new version of ROCm, you will need to re-load ``omnitrace``.
+
+To use ``omnitrace``, you may use the following commands
+
+.. code::
+
+    module load amd-mixed
+    module load omnitrace
+
+
+Omniperf
+--------
+
+OLCF provides installations of AMD's `Omniperf <https://github.com/AMDResearch/omniperf>`_ profiling tools on Frontier.
+AMD provides documentation on the usage of Omniperf at `<https://amdresearch.github.io/omniperf/>`_.
+This section details the installation and common pitfalls of the ``omniperf`` module on Frontier.
+
+The ``omniperf`` module relies on two other modules -- a ROCm module (``amd``, ``amd-mixed``, or ``rocm``) and optionally a ``cray-python`` module.
+A ROCm module must be loaded before being able to do view or load the ``omniperf`` module.
+As for ``cray-python``, ``omniperf`` is a Python script and has several dependencies that cannot be met by the system's default Python, and are not met by the default ``cray-python`` installation.
+As such, you must either (1) load the ``cray-python`` module or (2) satisfy the Python dependencies in your own Python environment (ie, in a Conda environment).
+
+As a rule of thumb, always load the ``omniperf`` module last (especially after you load a ROCm module like ``amd``, ``rocm``, ``amd-mixed``).
+If you load a new version of ROCm, you will need to re-load ``omniperf``.
+
+Using ``cray-python``
+^^^^^^^^^^^^^^^^^^^^^
+
+To use ``omniperf`` with ``cray-python``, you may use the following commands:
+
+.. code::
+
+    module load amd-mixed
+    module load cray-python
+    module load omniperf
+
+No more work is needed on your part -- ``omniperf`` points to a directory that contains pre-built libraries for the ``cray-python`` version you are running.
+It is **critically** important that if you load a different version of ROCm or ``cray-python`` that you re-load ``omniperf``.
+
+.. note::
+
+    Omniperf requires relatively new versions of many dependencies.
+    Installing dependencies may break some currently installed packages that require older versions of the dependencies.
+    It is recommended that you use the newest ``cray-python`` modules available.
+
+
+Using your own Python
+^^^^^^^^^^^^^^^^^^^^^
+
+To use ``omniperf`` with your own Python installation, you must first install the dependencies of Omniperf in your Python's environment.
+To do so, use the ``requirements.txt`` file in the `Omniperf GitHub Repo <https://github.com/AMDResearch/omniperf>`_.
+You may install the dependencies using a command like:
+
+.. code::
+
+    python3 -m pip install -r requirements.txt
+
+Once you have installed the dependencies, you may load ``omniperf`` using commands like:
+
+.. code::
+
+    # Your Python environment should be active by this point
+    module load amd-mixed
+    module load omniperf
+
+Again, it is **critically** important that if you load a different version of ROCm that you re-load ``omniperf``.
+
+
+----
+
+Notable Differences between Summit and Crusher
+==============================================
+
+This section details 'tips and tricks' and information of interest to users when porting from Summit to Crusher.
+
+Using reduced precision (FP16 and BF16 datatypes)
+--------------------------------------------------------
+Users leveraging BF16 and FP16 datatypes for applications such as ML/AI training and low-precision matrix multiplication should be aware that the AMD MI250X GPU has different denormal handling than the V100 GPUs on Summit. On the MI250X, the V_DOT2 and the matrix instructions for FP16 and BF16 flush input and output denormal values to zero. FP32 and FP64 MFMA instructions do not flush input and output denormal values to zero. 
+
+When training deep learning models using FP16 precision, some models may fail to converge with FP16 denorms flushed to zero. This occurs in operations encountering denormal values, and so is more likely to occur in FP16 because of a small dynamic range. BF16 numbers have a larger dynamic range than FP16 numbers and are less likely to encounter denormal values.
+
+AMD has provided a solution in ROCm 5.0 which modifies the behavior of Tensorflow, PyTorch, and rocBLAS. This modification starts with FP16 input values, casting the intermediate FP16 values to BF16, and then casting back to FP16 output after the accumulate FP32 operations. In this way, the input and output types are unchanged. The behavior is enabled by default in machine learning frameworks. This behavior requires user action in rocBLAS, via a special enum type. For more information, see the rocBLAS link below. 
+
+If you encounter significant differences when running using reduced precision, explore replacing non-converging models in FP16 with BF16, because of the greater dynamic range in BF16. We recommend using BF16 for ML models in general. If you have further questions or encounter issues, contact help@olcf.ornl.gov.
+
+Additional information on MI250X reduced precision can be found at:
+  * The MI250X ISA specification details the flush to zero denorm behavior at: https://developer.amd.com/wp-content/resources/CDNA2_Shader_ISA_18November2021.pdf (See page 41 and 46)
+  * AMD rocBLAS library reference guide details this behavior at: https://rocblas.readthedocs.io/en/master/API_Reference_Guide.html#mi200-gfx90a-considerations
+
+Enabling GPU Page Migration
+---------------------------
+The AMD MI250X and operating system on Crusher supports unified virtual addressing across the entire host and device memory, and automatic page migration between CPU and GPU memory. Migratable, universally addressable memory is sometimes called 'managed' or 'unified' memory, but neither of these terms fully describes how memory may behave on Crusher. In the following section we'll discuss how the heterogenous memory space on a Crusher node is surfaced within your application.
+
+The accessibility of memory from GPU kernels and whether pages may migrate depends three factors: how the memory was allocated; the XNACK operating mode of the GPU; whether the kernel was compiled to support page migration. The latter two factors are intrinsically linked, as the MI250X GPU operating mode restricts the types of kernels which may run.
+
+XNACK (pronounced X-knack) refers to the AMD GPU's ability to retry memory accesses that fail due to a page fault. The XNACK mode of an MI250X can be changed by setting the environment variable ``HSA_XNACK`` before starting a process that uses the GPU. Valid values are 0 (disabled) and 1 (enabled), and all processes connected to a GPU must use the same XNACK setting. The default MI250X on Crusher is ``HSA_XNACK=0``.
+
+If ``HSA_XNACK=0``, page faults in GPU kernels are not handled and will terminate the kernel. Therefore all memory locations accessed by the GPU must either be resident in the GPU HBM or mapped by the HIP runtime. Memory regions may be migrated between the host DDR4 and GPU HBM using explicit HIP library functions such as ``hipMemAdvise`` and ``hipPrefetchAsync``, but memory will not be automatically migrated based on access patterns alone.
+
+If ``HSA_XNACK=1``, page faults in GPU kernels will trigger a page table lookup. If the memory location can be made accessible to the GPU, either by being migrated to GPU HBM or being mapped for remote access, the appropriate action will occur and the access will be replayed. Page migration  will happen between CPU DDR4 and GPU HBM according to page touch. The exceptions are if the programmer uses a HIP library call such as ``hipPrefetchAsync`` to request migration, or if a preferred location is set via ``hipMemAdvise``, or if GPU HBM becomes full and the page must forcibly be evicted back to CPU DDR4 to make room for other data.
+
+..
+   If ``HSA_XNACK=1``, page faults in GPU kernels will trigger a page table lookup. If the memory location can be made accessible to the GPU, either by being migrated to GPU HBM or being mapped for remote access, the appropriate action will occur and the access will be replayed. Once a memory region has been migrated to GPU HBM it typically stays there rather than migrating back to CPU DDR4. The exceptions are if the programmer uses a HIP library call such as ``hipPrefetchAsync`` to request migration, or if GPU HBM becomes full and the page must forcibly be evicted back to CPU DDR4 to make room for other data.
+
+
+Migration of Memory by Allocator and XNACK Mode
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Most applications that use "managed" or "unified" memory on other platforms will want to enable XNACK to take advantage of automatic page migration on Crusher. The following table shows how common allocators currently behave with XNACK enabled. The behavior of a specific memory region may vary from the default if the programmer uses certain API calls.
+
+
+.. note::
+   The page migration behavior summarized by the following tables represents the current, observable behavior. Said behavior will likely change in the near future.
+
+    ..
+       CPU accesses to migratable memory may behave differently than other platforms you're used to. On Crusher, pages will not migrate from GPU HBM to CPU DDR4 based on access patterns alone. Once a page has migrated to GPU HBM it will remain there even if the CPU accesses it, and all accesses which do not resolve in the CPU cache will occur over the Infinity Fabric between the AMD "Optimized 3rd Gen EPYC" CPU and AMD MI250X GPU. Pages will only *automatically* migrate back to CPU DDR4 if they are forcibly evicted to free HBM capacity, although programmers may use HIP APIs to manually migrate memory regions.
+
+``HSA_XNACK=1`` **Automatic Page Migration Enabled**
+
+..
+   +---------------------------------------------+---------------------------+--------------------------------------------+----------------------------------------------------+
+   | Allocator                                   | Initial Physical Location | CPU Access after GPU First Touch           | Default Behavior for GPU Access                    |
+   +=============================================+===========================+============================================+====================================================+
+   | System Allocator (malloc,new,allocate, etc) | Determined by first touch | Zero copy read/write                       | Migrate to GPU HBM on touch, then local read/write |
+   +---------------------------------------------+---------------------------+--------------------------------------------+----------------------------------------------------+
+   | hipMallocManaged                            | GPU HBM                   | Zero copy read/write                       | Populate in  GPU HBM, then local read/write        |
+   +---------------------------------------------+---------------------------+--------------------------------------------+----------------------------------------------------+
+   | hipHostMalloc                               | CPU DDR4                  | Local read/write                           | Zero copy read/write over Infinity Fabric          |
+   +---------------------------------------------+---------------------------+--------------------------------------------+----------------------------------------------------+
+   | hipMalloc                                   | GPU HBM                   | Zero copy read/write over Inifinity Fabric | Local read/write                                   |
+   +---------------------------------------------+---------------------------+--------------------------------------------+----------------------------------------------------+
+
++---------------------------------------------+---------------------------+--------------------------------------------+----------------------------------------------------+
+| Allocator                                   | Initial Physical Location | CPU Access after GPU First Touch           | Default Behavior for GPU Access                    |
++=============================================+===========================+============================================+====================================================+
+| System Allocator (malloc,new,allocate, etc) | CPU DDR4                  | Migrate to CPU DDR4 on touch               | Migrate to GPU HBM on touch                        |
++---------------------------------------------+---------------------------+--------------------------------------------+----------------------------------------------------+
+| hipMallocManaged                            | CPU DDR4                  | Migrate to CPU DDR4 on touch               | Migrate to GPU HBM on touch                        |
++---------------------------------------------+---------------------------+--------------------------------------------+----------------------------------------------------+
+| hipHostMalloc                               | CPU DDR4                  | Local read/write                           | Zero copy read/write over Infinity Fabric          |
++---------------------------------------------+---------------------------+--------------------------------------------+----------------------------------------------------+
+| hipMalloc                                   | GPU HBM                   | Zero copy read/write over Inifinity Fabric | Local read/write                                   |
++---------------------------------------------+---------------------------+--------------------------------------------+----------------------------------------------------+
+   
+Disabling XNACK will not necessarily result in an application failure, as most types of memory can still be accessed by the AMD "Optimized 3rd Gen EPYC" CPU and AMD MI250X GPU. In most cases, however, the access will occur in a zero-copy fashion over the Infinity Fabric. The exception is memory allocated through standard system allocators such as ``malloc``, which cannot be accessed directly from GPU kernels without previously being registered via a HIP runtime call such as ``hipHostRegister``. Access to malloc'ed and unregistered memory from GPU kernels will result in fatal unhandled page faults. The table below shows how common allocators behave with XNACK disabled.
+
+``HSA_XNACK=0`` **Automatic Page Migration Disabled**
+
++---------------------------------------------+---------------------------+--------------------------------------------+---------------------------------------------+
+| Allocator                                   | Initial Physical Location | Default Behavior for CPU Access            | Default Behavior for GPU Access             | 
++=============================================+===========================+============================================+=============================================+
+| System Allocator (malloc,new,allocate, etc) | CPU DDR4                  | Local read/write                           | Fatal Unhandled Page Fault                  |
++---------------------------------------------+---------------------------+--------------------------------------------+---------------------------------------------+
+| hipMallocManaged                            | CPU DDR4                  | Local read/write                           | Zero copy read/write over Infinity Fabric   |
++---------------------------------------------+---------------------------+--------------------------------------------+---------------------------------------------+
+| hipHostMalloc                               | CPU DDR4                  | Local read/write                           | Zero copy read/write over Infinity Fabric   |
++---------------------------------------------+---------------------------+--------------------------------------------+---------------------------------------------+
+| hipMalloc                                   | GPU HBM                   | Zero copy read/write over Inifinity Fabric | Local read/write                            |
++---------------------------------------------+---------------------------+--------------------------------------------+---------------------------------------------+
+
+Compiling HIP kernels for specific XNACK modes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Although XNACK is a capability of the MI250X GPU, it does require that kernels be able to recover from page faults. Both the ROCm and CCE HIP compilers will default to generating code that runs correctly with both XNACK enabled and disabled. Some applications may benefit from using the following compilation options to target specific XNACK modes.
+
+| ``hipcc --amdgpu-target=gfx90a`` or ``CC --offload-arch=gfx90a -x hip``
+|   Kernels are compiled to a single "xnack any" binary, which will run correctly with both XNACK enabled and XNACK disabled.
+
+| ``hipcc --amdgpu-target=gfx90a:xnack+`` or ``CC --offload-arch=gfx90a:xnack+ -x hip``
+|   Kernels are compiled in "xnack plus" mode and will *only* be able to run on GPUs with ``HSA_XNACK=1`` to enable XNACK. Performance may be better than "xnack any", but attempts to run with XNACK disabled will fail.
+
+| ``hipcc --amdgpu-target=gfx90a:xnack-`` or ``CC --offload-arch=gfx90a:xnack- -x hip``
+|   Kernels are compiled in "xnack minus" mode and will *only* be able to run on GPUs with ``HSA_XNACK=0`` and XNACK disabled. Performance may be better than "xnack any", but attempts to run with XNACK enabled will fail.
+
+| ``hipcc --amdgpu-target=gfx90a:xnack- --amdgpu-target=gfx90a:xnack+ -x hip`` or ``CC --offload-arch=gfx90a:xnack- --offload-arch=gfx90a:xnack+ -x hip``
+|   Two versions of each kernel will be generated, one that runs with XNACK disabled and one that runs if XNACK is enabled. This is different from "xnack any" in that two versions of each kernel are compiled and HIP picks the appropriate one at runtime, rather than there being a single version compatible with both. A "fat binary" compiled in this way will have the same performance of "xnack+" with ``HSA_XNACK=1`` and as "xnack-" with ``HSA_XNACK=0``, but the final executable will be larger since it contains two copies of every kernel.
+
+If the HIP runtime cannot find a kernel image that matches the XNACK mode of the device, it will fail with ``hipErrorNoBinaryForGpu``.
+
+.. code::
+
+    $ HSA_XNACK=0 srun -n 1 -N 1 -t 1 ./xnack_plus.exe
+    "hipErrorNoBinaryForGpu: Unable to find code object for all current devices!"
+    srun: error: crusher002: task 0: Aborted
+    srun: launch/slurm: _step_signal: Terminating StepId=74100.0
+
+
+..
+    NOTE: This works in my shell because I used cpan to install the URI::Encode perl modules.
+    This won't work generically unless those get installed, so commenting out this block now.
+
+    The AMD tool `roc-obj-ls` will let you see what code objects are in a binary.
+
+    .. code::
+        $ hipcc --amdgpu-target=gfx90a:xnack+ square.hipref.cpp -o xnack_plus.exe
+        $ roc-obj-ls -v xnack_plus.exe
+        Bundle# Entry ID:                                                              URI:
+        1       host-x86_64-unknown-linux                                           file://xnack_plus.exe#offset=8192&size=0
+        1       hipv4-amdgcn-amd-amdhsa--gfx90a:xnack+                              file://xnack_plus.exe#offset=8192&size=9752
+
+    If no XNACK flag is specificed at compilation the default is "xnack any", and objects in `roc-obj-ls` with not have an XNACK mode specified.
+
+    .. code::
+        $ hipcc --amdgpu-target=gfx90a square.hipref.cpp -o xnack_any.exe
+        $ roc-obj-ls -v xnack_any.exe
+        Bundle# Entry ID:                                                              URI:
+        1       host-x86_64-unknown-linux                                           file://xnack_any.exe#offset=8192&size=0
+        1       hipv4-amdgcn-amd-amdhsa--gfx90a                                     file://xnack_any.exe#offset=8192&size=9752
+
+One way to diagnose ``hipErrorNoBinaryForGpu`` messages is to set the environment variable ``AMD_LOG_LEVEL`` to 1 or greater:
+
+.. code::
+    
+    $ AMD_LOG_LEVEL=1 HSA_XNACK=0 srun -n 1 -N 1 -t 1 ./xnack_plus.exe
+    :1:rocdevice.cpp            :1573: 43966598070 us: HSA_AMD_AGENT_INFO_SVM_DIRECT_HOST_ACCESS query failed.
+    :1:rocdevice.cpp            :1573: 43966598762 us: HSA_AMD_AGENT_INFO_SVM_DIRECT_HOST_ACCESS query failed.
+    :1:rocdevice.cpp            :1573: 43966599392 us: HSA_AMD_AGENT_INFO_SVM_DIRECT_HOST_ACCESS query failed.
+    :1:rocdevice.cpp            :1573: 43966599970 us: HSA_AMD_AGENT_INFO_SVM_DIRECT_HOST_ACCESS query failed.
+    :1:rocdevice.cpp            :1573: 43966600550 us: HSA_AMD_AGENT_INFO_SVM_DIRECT_HOST_ACCESS query failed.
+    :1:rocdevice.cpp            :1573: 43966601109 us: HSA_AMD_AGENT_INFO_SVM_DIRECT_HOST_ACCESS query failed.
+    :1:rocdevice.cpp            :1573: 43966601673 us: HSA_AMD_AGENT_INFO_SVM_DIRECT_HOST_ACCESS query failed.
+    :1:rocdevice.cpp            :1573: 43966602248 us: HSA_AMD_AGENT_INFO_SVM_DIRECT_HOST_ACCESS query failed.
+    :1:hip_code_object.cpp      :460 : 43966602806 us: hipErrorNoBinaryForGpu: Unable to find code object for all current devices!
+    :1:hip_code_object.cpp      :461 : 43966602810 us:   Devices:
+    :1:hip_code_object.cpp      :464 : 43966602811 us:     amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack- - [Not Found]
+    :1:hip_code_object.cpp      :464 : 43966602811 us:     amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack- - [Not Found]
+    :1:hip_code_object.cpp      :464 : 43966602812 us:     amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack- - [Not Found]
+    :1:hip_code_object.cpp      :464 : 43966602813 us:     amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack- - [Not Found]
+    :1:hip_code_object.cpp      :464 : 43966602813 us:     amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack- - [Not Found]
+    :1:hip_code_object.cpp      :464 : 43966602814 us:     amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack- - [Not Found]
+    :1:hip_code_object.cpp      :464 : 43966602814 us:     amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack- - [Not Found]
+    :1:hip_code_object.cpp      :464 : 43966602815 us:     amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack- - [Not Found]
+    :1:hip_code_object.cpp      :468 : 43966602816 us:   Bundled Code Objects:
+    :1:hip_code_object.cpp      :485 : 43966602817 us:     host-x86_64-unknown-linux - [Unsupported]
+    :1:hip_code_object.cpp      :483 : 43966602818 us:     hipv4-amdgcn-amd-amdhsa--gfx90a:xnack+ - [code object v4 is amdgcn-amd-amdhsa--gfx90a:xnack+]
+    "hipErrorNoBinaryForGpu: Unable to find code object for all current devices!"
+    srun: error: crusher129: task 0: Aborted
+    srun: launch/slurm: _step_signal: Terminating StepId=74102.0
+
+The above log messages indicate the type of image required by each device, given its current mode (``amdgcn-amd-amdhsa--gfx90a:sramecc+:xnack-``) and the images found in the binary (``hipv4-amdgcn-amd-amdhsa--gfx90a:xnack+``).
+
+----
+
+Floating-Point (FP) Atomic Operations and Coarse/Fine Grained Memory Allocations
+--------------------------------------------------------------------------------
+
+The Crusher system, equipped with CDNA2-based architecture MI250X cards, offers a coherent host interface that enables advanced memory and unique cache coherency capabilities.
+The AMD driver leverages the Heterogeneous Memory Management (HMM) support in the Linux kernel to perform seamless page migrations to/from CPU/GPUs.
+This new capability comes with a memory model that needs to be understood completely to avoid unexpected behavior in real applications. For more details, please visit the previous section.
+
+AMD GPUs can allocate two different types of memory locations: 1) Coarse grained and 2) Fine grained.
+
+**Coarse grained** memory is only guaranteed to be coherent outside of GPU kernels that modify it, enabling higher performance memory operations. Changes applied to coarse-grained memory by a GPU kernel are  only visible to the rest of the system (CPU or other GPUs) when the kernel has completed. A GPU kernel is only guaranteed to see changes applied to coarse grained memory by the rest of the system (CPU or other GPUs) if those changes were made before the kernel launched.
+
+**Fine grained** memory allows CPUs and GPUs to synchronize (via atomics) and coherently communicate with each other while the GPU kernel is running, allowing more advanced programming patterns. The additional visibility impacts the performance of fine grained allocated memory.
+
+The fast hardware-based Floating point (FP) atomic operations available on MI250X are assumed to be working on coarse grained memory regions; when these instructions are applied to a fine-grained memory region, they will silently produce a no-op. To avoid returning incorrect results, the compiler never emits hardware-based FP atomics instructions by default, even when applied to coarse grained memory regions. Currently, users can use the `-munsafe-fp-atomics` flag to force the compiler to emit hardware-based FP atomics.
+Using hardware-based FP atomics translates in a substantial performance improvement over the default choice.
+
+Users applying floating point atomic operations (e.g., atomicAdd) on memory regions allocated via regular hipMalloc() can safely apply the `-munsafe-fp-atomics` flags to their codes to get the best possible performance and leverage hardware supported floating point atomics.
+Atomic operations supported in hardware on non-FP datatypes  (e.g., INT32) will work correctly regardless of the nature of the memory region used.
+
+In ROCm-5.1 and earlier versions, the flag `-munsafe-fp-atomics` is interpreted as a suggestion by the compiler, whereas from ROCm-5.2 the flag will always enforce the use of fast hardware-based FP atomics.
+
+The following tables summarize the result granularity of various combinations of allocators, flags and arguments.
+
+For ``hipHostMalloc()``, the following table shows the nature of the memory returned based on the flag passed as argument.
+
++----------------------+---------------------------+-----------------+
+| API                  | Flag                      | Results         |
++======================+===========================+=================+
+| hipHostMalloc()      | hipHostMallocDefault      |  Fine grained   |
++----------------------+---------------------------+-----------------+
+| hipHostMalloc()      | hipHostMallocNonCoherent  | Coarse grained  |
++----------------------+---------------------------+-----------------+
+
+The following table shows the nature of the memory returned based on the flag passed as argument to ``hipExtMallocWithFlags()``.
+
++---------------------------+------------------------------+-------------------------+
+| API                       |  Flag                        |  Result                 |
++===========================+==============================+=========================+
+| hipExtMallocWithFlags()   | hipDeviceMallocDefault       |  Coarse grained         |
++---------------------------+------------------------------+-------------------------+
+| hipExtMallocWithFlags()   | hipDeviceMallocFinegrained   |  Fine grained           |
++---------------------------+------------------------------+-------------------------+
+
+Finally, the following table summarizes the nature of the memory returned based on the flag passed as argument to ``hipMallocManaged()`` and the use of CPU regular ``malloc()`` routine with the possible use of ``hipMemAdvise()``.
+
++----------------------+---------------------------------------------+-------------------------+
+| API                  |  MemAdvice                                  |  Result                 |
++======================+=============================================+=========================+
+| hipMallocManaged()   |                                             |  Fine grained           |
++----------------------+---------------------------------------------+-------------------------+
+| hipMallocManaged()   | hipMemAdvise (hipMemAdviseSetCoarseGrain)   |  Coarse grained         |
++----------------------+---------------------------------------------+-------------------------+
+| malloc()             |                                             |  Fine grained           |
++----------------------+---------------------------------------------+-------------------------+
+| malloc()             | hipMemAdvise (hipMemAdviseSetCoarseGrain)   |  Coarse grained         |
++----------------------+---------------------------------------------+-------------------------+
+
+
+Performance considerations for LDS FP atomicAdd()
+-------------------------------------------------
+
+Hardware FP atomic operations performed in LDS memory are usually always faster than an equivalent CAS loop, in particular when contention on LDS memory locations is high.
+Because of a hardware design choice, FP32 LDS atomicAdd() operations can be slower than equivalent FP64 LDS atomicAdd(), in particular when contention on memory locations is low (e.g. random access pattern).
+The aforementioned behavior is only true for FP atomicAdd() operations. Hardware atomic operations for CAS/Min/Max on FP32 are usually faster than the FP64 counterparts.
+In cases when contention is very low, a FP32 CAS loop implementing an atomicAdd() operation could be faster than an hardware FP32 LDS atomicAdd().
+Applications using single precision FP atomicAdd() are encouraged to experiment with the use of double precision to evaluate the trade-off between high atomicAdd() performance vs. potential lower occupancy due to higher LDS usage.
+
+------
+
+System Updates 
+============== 
+
+2024-03-19
+----------
+On Tuesday, March 19, 2024, Frontier's system software was upgraded to Slingshot 2.1.1 and Slingshot Host Software 2.1.2. If you encounter any issues or have questions, please contact help@olcf.ornl.gov.
+
+2024-01-23
+----------
+On Tuesday, January 23, 2024, Crusher's system software was upgraded. The following changes took place:
+
+-  ROCm 6.0.0 is now available via the ``rocm/6.0.0`` modulefile.
+-  HPE/Cray Programming Environment (PE) 23.12 is now available via the ``cpe/23.12`` modulefile.
+-  ROCm 5.3.0 and HPE/Cray PE 22.12 remain as default.
+-  The system was upgraded to AMD GPU 6.3.6 device driver (ROCm 6.0.0 release). 
+
+Please note that target default versions will be updated to PE 23.12 and ROCm 5.7.1 in the near future. Users are encouraged to try both and report any issues to help@olcf.ornl.gov.
+
+2023-12-05
+----------
+On Tuesday, December 5, 2023, Crusher's system software was upgraded. The following changes took place:
+
+-  ROCm 5.7.1 is now available via the ``rocm/5.7.1`` modulefile.
+-  Flux 0.56.0 is now available via the ``flux/0.56.0`` modulefile.
+
+2023-10-03
+----------
+On Tuesday, October 3, 2023, Crusher's system software was upgraded. The following changes took place:
+
+-  The system was to the AMD GPU 6.1.5 device driver (ROCm 5.6.1 release).
+-  Slurm was upgraded to version 23.02.5
+
+2023-09-19
+----------
+On Tuesday, September 19, 2023, Crusher's system software was upgraded. The following changes took place:
+
+-  The system was upgraded to Slingshot Host Software 2.1.0. 
+-  ROCm 5.6.0 and 5.7.0 are now available via the ``rocm/5.6.0`` and ``rocm/5.7.0`` modulefiles, respectively.
+-  HPE/Cray Programming Environments (PE) 23.09 is now available via the ``cpe/23.09`` modulefile.
+-  ROCm 5.3.0 and HPE/Cray PE 22.12 remain as default.
+
+2023-07-18
+----------
+On Tuesday, July 18, 2023, the Crusher TDS was upgraded to a new version of the system software stack. During the upgrade, the following changes took place:
+
+-  The system was upgraded to Cray OS 2.5, Slingshot Host Software 2.0.2-112, and the AMD GPU 6.0.5 device driver (ROCm 5.5.1 release).
+-  ROCm 5.5.1 is now available via the ``rocm/5.5.1`` modulefile.
+-  HPE/Cray Programming Environments (PE) 23.05 is now available via the ``cpe/23.05`` modulefile.
+-  HPE/Cray PE 23.05 introduces support for ROCm 5.5.1. However, due to issues identified during testing, ROCm 5.3.0 and HPE/Cray PE 22.12 remain as default.
+
+2023-04-05
+----------
+
+On Wednesday, April 5, 2023, the Crusher TDS was upgraded to a new software stack.  A summary of the changes is included below. 
+
+-  The operating system was upgraded to Cray OS 2.4 based on SLES 15.4.
+-  HPE/Cray Programming Environment (PE):
+    -  PE 22.12 was installed and is now default. This PE includes the following components:
+        -  Cray MPICH 8.1.23
+        -  Cray Libsci 22.12.1.1
+        -  CCE 15.0.0
+    -  PE 23.03 is now also available and includes:
+        -  Cray MPICH 8.1.25
+        -  Cray Libsci 23.02.1.1
+        -  CCE 15.0.1
+-  ROCm: 
+    -  ROCm 5.3.0 is now default.
+    -  ROCm 5.4.0 and 5.4.3 are available.
+-  File Systems:
+    -  The Orion Lustre parallel file system is now available on Crusher. 
+    -  The Alpine GPFS file system remains available but will be permanently unmounted from Crusher on Tuesday, April 18, 2023. Please begin moving your data to the Orion file system as soon as possible.
+
+
+2022-12-29 
+---------- 
+
+On Thursday, December 29, 2022 the following system configuration settings will be updated on Crusher:
+
+ * Low-Noise Mode will be enabled: as a result, system processes will be constrained to core 0 on every node.
+ * Slurm's core specialization default will change: Slurm ``--core-spec`` or ``-S`` value will be set to 8. This will provide a symmetric distribution of cores per GCD to the application and will reserve one core per L3 cache region. After the outage, the default number of cores available to each GCD on a node will be 7. To change from the new default value, you can set ``--core-spec`` or ``-S`` in your job submission.
+ * The default NIC mapping will be updated to ``MPICH_OFI_NIC_POLICY=NUMA`` to address known issues described in `OLCFDEV-192 <https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1292-crusher-default-nic-binding-is-not-ideal>`__ and `OLCFDEV-1366 <https://docs.olcf.ornl.gov/systems/crusher_quick_start_guide.html#olcfdev-1366-ofi-poll-failed-errors-with-gpu-aware-mpi>`__.
+
+
+------
+
+Getting Help
+============
+
+If you have problems or need helping running on Crusher, please submit a ticket
+by emailing help@olcf.ornl.gov.
+
+

--- a/systems/crusher_quick_start_guide.rst
+++ b/systems/crusher_quick_start_guide.rst
@@ -1,3 +1,4 @@
+:no-search:
 .. _crusher-quick-start-guide:
 
 *************************
@@ -5,11 +6,9 @@ Crusher Quick-Start Guide
 *************************
 
 .. warning::
-    **The Crusher Test and Development System will be decommissioned on April 12th, 2024.** The
-    file systems that were available on Crusher are still accessible from the Home
-    server and the Data Transfer Nodes (DTNs), so all your data will remain accessible.
-    If you do not have access to other OLCF systems, your project will move to data-only
-    for 30-days. If you have any questions, please contact help@olcf.ornl.gov.
+
+  This system was decommissioned on April 12, 2024 and is no longer online.
+  Information here is presented as an archive and is no longer updated.
 
 .. _crusher-system-overview:
 

--- a/systems/index.rst
+++ b/systems/index.rst
@@ -12,4 +12,15 @@ Systems
    andes_user_guide
    home_user_guide
    dtn_user_guide
-   odo_user_guide 
+   odo_user_guide
+
+Legacy Systems
+==============
+
+.. toctree::
+   :maxdepth: 1
+
+   crusher_quick_start_guide.rst
+   spock_quick_start_guide
+   summit_user_guide
+   ascent_user_guide

--- a/systems/spock_quick_start_guide.rst
+++ b/systems/spock_quick_start_guide.rst
@@ -1,0 +1,1058 @@
+.. _spock-quick-start-guide:
+
+***********************
+Spock Quick-Start Guide
+***********************
+
+.. warning::
+    **The Spock Early Access System was decommissioned on March 15, 2023.** The
+    file systems that were available on Spock are still accessible from the Home 
+    server and the Data Transfer Nodes (DTN), so all your data will remain accessible. 
+    If you do not have access to other OLCF systems, your project will move to data-only
+    for 30-days. If you have any questions, please contact help@olcf.ornl.gov.
+
+.. _spock-system-overview:
+
+System Overview
+===============
+
+Spock is an NCCS moderate-security system that contains similar hardware and
+software as the upcoming Frontier system. It is used as an early-access testbed
+for Center for Accelerated Application Readiness (CAAR) and Exascale Computing
+Project (ECP) teams as well as NCCS staff and our vendor partners. The system
+has 3 cabinets, each containing 12 compute nodes, for a total of 36 compute
+nodes.
+
+.. _spock-compute-nodes:
+
+Spock Compute Nodes
+-------------------
+
+Each Spock compute node consists of [1x] 64-core AMD EPYC 7662 "Rome" CPU (with
+2 hardware threads per physical core) with access to 256 GB of DDR4 memory and
+connected to [4x] AMD MI100 GPUs. The CPU is connected to all GPUs via PCIe
+Gen4, allowing peak host-to-device (H2D) and device-to-host (D2H) data
+transfers of 32+32 GB/s. The GPUs are connected in an all-to-all arrangement
+via Infinity Fabric (xGMI), allowing for a peak device-to-device bandwidth of
+46+46 GB/s. Each compute node also has [2x] 3.2 TB NVMe devices (SSDs) with
+sequential read and write speeds of 6900 MB/s and 4200 MB/s, respectively.
+
+.. note::
+    The X+X GB/s values for bandwidths above represent bi-directional bandwidths. So, for example, the Infinity Fabric connecting any two GPUs allows peak data transfers of 46 GB/s *in both directions simultaneously*.
+
+.. image:: /images/Spock_Node.jpg
+   :align: center
+   :width: 100%
+   :alt: Spock node architecture diagram
+
+.. note::
+    There are 4 NUMA domains per node, that are defined as follows:
+
+    * NUMA 0: hardware threads 000-015, 064-079 | GPU 0
+    * NUMA 1: hardware threads 016-031, 080-095 | GPU 1
+    * NUMA 2: hardware threads 032-047, 096-111 | GPU 2
+    * NUMA 3: hardware threads 048-063, 112-127 | GPU 3
+
+System Interconnect
+-------------------
+
+The Spock nodes are connected with Slingshot-10 providing a node injection
+bandwidth of 12.5 GB/s.
+
+File Systems
+------------
+
+Spock is connected to an IBM Spectrum Scale™ filesystem providing 250 PB of
+storage capacity with a peak write speed of 2.5 TB/s. Spock also has access to
+the center-wide NFS-based filesystem (which provides user and project home
+areas). While Spock does not have *direct* access to the center’s Nearline archival storage system (Kronos) - for user and project archival storage - users can log in to the moderate DTNs to move data to/from Kronos or use the "OLCF Kronos" Globus collection. For more information on using Kronos, see the :ref:`kronos` section. 
+
+GPUs
+----
+
+Spock contains a total of 144 AMD MI100 GPUs. The AMD MI100 GPU has a peak
+performance of up to 11.5 TFLOPS in double-precision for modeling & simulation
+and up to 184.6 TFLOPS in half-precision for machine learning and data
+analytics. Each GPU contains 120 compute units (7680 stream processors) and 32
+GB of high-bandwidth memory (HBM2) which can be accessed at speeds of up to 1.2
+TB/s.
+
+----
+
+Connecting
+==========
+
+To connect to Spock, ``ssh`` to ``spock.olcf.ornl.gov``. For example:
+
+.. code-block:: bash
+
+    $ ssh username@spock.olcf.ornl.gov
+
+For more information on connecting to OLCF resources, see :ref:`connecting-to-olcf`.
+
+----
+
+Data and Storage
+================
+
+For more detailed information about center-wide file systems and data archiving
+available on Spock, please refer to the pages on
+:ref:`data-storage-and-transfers`, but the two subsections below give a quick
+overview of NFS and GPFS storage spaces.
+
+NFS
+---
+
++---------------------+---------------------------------------------+----------------+-------------+--------+---------+---------+------------+------------------+
+| Area                | Path                                        | Type           | Permissions |  Quota | Backups | Purged  | Retention  | On Compute Nodes |
++=====================+=============================================+================+=============+========+=========+=========+============+==================+
+| User Home           | ``/ccs/home/[userid]``                      | NFS            | User set    |  50 GB | Yes     | No      | 90 days    | Read-only        |
++---------------------+---------------------------------------------+----------------+-------------+--------+---------+---------+------------+------------------+
+| Project Home        | ``/ccs/proj/[projid]``                      | NFS            | 770         |  50 GB | Yes     | No      | 90 days    | Read-only        |
++---------------------+---------------------------------------------+----------------+-------------+--------+---------+---------+------------+------------------+
+
+GPFS
+----
+
++---------------------+---------------------------------------------+----------------+-------------+--------+---------+---------+------------+------------------+
+| Area                | Path                                        | Type           | Permissions |  Quota | Backups | Purged  | Retention  | On Compute Nodes |
++=====================+=============================================+================+=============+========+=========+=========+============+==================+
+| Member Work         | ``/gpfs/alpine/[projid]/scratch/[userid]``  | Spectrum Scale | 700         |  50 TB | No      | 90 days | N/A        | Yes              |
++---------------------+---------------------------------------------+----------------+-------------+--------+---------+---------+------------+------------------+
+| Project Work        | ``/gpfs/alpine/[projid]/proj-shared``       | Spectrum Scale | 770         |  50 TB | No      | 90 days | N/A        | Yes              |
++---------------------+---------------------------------------------+----------------+-------------+--------+---------+---------+------------+------------------+
+| World Work          | ``/gpfs/alpine/[projid]/world-shared``      | Spectrum Scale | 775         |  50 TB | No      | 90 days | N/A        | Yes              |
++---------------------+---------------------------------------------+----------------+-------------+--------+---------+---------+------------+------------------+
+
+----
+
+Programming Environment
+=======================
+
+OLCF provides Spock users many pre-installed software packages and scientific
+libraries. To facilitate this, environment management tools are used to handle
+necessary changes to the shell.
+
+Environment Modules (Lmod)
+--------------------------
+
+Environment modules are provided through `Lmod
+<https://lmod.readthedocs.io/en/latest/>`__, a Lua-based module system for
+dynamically altering shell environments. By managing changes to the shell’s
+environment variables (such as ``PATH``, ``LD_LIBRARY_PATH``, and
+``PKG_CONFIG_PATH``), Lmod allows you to alter the software available in your
+shell environment without the risk of creating package and version combinations
+that cannot coexist in a single environment.
+
+General Usage
+^^^^^^^^^^^^^
+
+The interface to Lmod is provided by the ``module`` command:
+
++------------------------------------+-------------------------------------------------------------------------+
+| Command                            | Description                                                             |
++====================================+=========================================================================+
+| ``module -t list``                 | Shows a terse list of the currently loaded modules                      |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module avail``                   | Shows a table of the currently available modules                        |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module help <modulename>``       | Shows help information about ``<modulename>``                           |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module show <modulename>``       | Shows the environment changes made by the ``<modulename>`` modulefile   |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module spider <string>``         | Searches all possible modules according to ``<string>``                 |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module load <modulename> [...]`` | Loads the given ``<modulename>``\(s) into the current environment       |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module use <path>``              | Adds ``<path>`` to the modulefile search cache and ``MODULESPATH``      |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module unuse <path>``            | Removes ``<path>`` from the modulefile search cache and ``MODULESPATH`` |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module purge``                   | Unloads all modules                                                     |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module reset``                   | Resets loaded modules to system defaults                                |
++------------------------------------+-------------------------------------------------------------------------+
+| ``module update``                  | Reloads all currently loaded modules                                    |
++------------------------------------+-------------------------------------------------------------------------+
+
+Searching for Modules
+^^^^^^^^^^^^^^^^^^^^^
+
+Modules with dependencies are only available when the underlying dependencies,
+such as compiler families, are loaded. Thus, module avail will only display
+modules that are compatible with the current state of the environment. To
+search the entire hierarchy across all possible dependencies, the ``spider``
+sub-command can be used as summarized in the following table.
+
++------------------------------------------+--------------------------------------------------------------------------------------+
+| Command                                  | Description                                                                          |
++==========================================+======================================================================================+
+| ``module spider``                        | Shows the entire possible graph of modules                                           |
++------------------------------------------+--------------------------------------------------------------------------------------+
+| ``module spider <modulename>``           | Searches for modules named ``<modulename>`` in the graph of possible modules         |
++------------------------------------------+--------------------------------------------------------------------------------------+
+| ``module spider <modulename>/<version>`` | Searches for a specific version of ``<modulename>`` in the graph of possible modules |
++------------------------------------------+--------------------------------------------------------------------------------------+
+| ``module spider <string>``               | Searches for modulefiles containing ``<string>``                                     |
++------------------------------------------+--------------------------------------------------------------------------------------+
+
+Compilers
+---------
+
+Cray, AMD, and GCC compilers are provided through modules on Spock. The Cray
+and AMD compilers are both based on LLVM/Clang. There are also system/OS
+versions of both Clang and GCC available in ``/usr/bin``. The table below lists
+details about each of the module-provided compilers.
+
+.. note::
+
+    It is highly recommended to use the Cray compiler wrappers (``cc``, ``CC``, and ``ftn``) whenever possible. See the next section for more details.
+
+
++--------+-------------------------+-----------------+----------+-------------------+---------------------------------+
+| Vendor | Programming Environment | Compiler Module | Language | Compiler Wrapper  | Compiler                        |
++========+=========================+=================+==========+===================+=================================+ 
+| Cray   | ``PrgEnv-cray``         | ``cce``         | C        | ``cc``            | ``craycc``                      |
+|        |                         |                 +----------+-------------------+---------------------------------+
+|        |                         |                 | C++      | ``CC``            | ``craycxx`` or ``crayCC``       |
+|        |                         |                 +----------+-------------------+---------------------------------+
+|        |                         |                 | Fortran  | ``ftn``           | ``crayftn``                     |
++--------+-------------------------+-----------------+----------+-------------------+---------------------------------+
+| AMD    | ``PrgEnv-amd``          | ``rocm``        | C        | ``cc``            | ``$ROCM_PATH/llvm/bin/clang``   |
+|        |                         |                 +----------+-------------------+---------------------------------+
+|        |                         |                 | C++      | ``CC``            | ``$ROCM_PATH/llvm/bin/clang++`` |
+|        |                         |                 +----------+-------------------+---------------------------------+
+|        |                         |                 | Fortran  | ``ftn``           | ``$ROCM_PATH/llvm/bin/flang``   |
++--------+-------------------------+-----------------+----------+-------------------+---------------------------------+
+| GCC    | ``PrgEnv-gnu``          | ``gcc``         | C        | ``cc``            | ``$GCC_PATH/bin/gcc``           |
+|        |                         |                 +----------+-------------------+---------------------------------+
+|        |                         |                 | C++      | ``CC``            | ``$GCC_PATH/bin/g++``           |
+|        |                         |                 +----------+-------------------+---------------------------------+
+|        |                         |                 | Fortran  | ``ftn``           | ``$GCC_PATH/bin/gfortran``      |
++--------+-------------------------+-----------------+----------+-------------------+---------------------------------+
+
+
+Cray Programming Environment and Compiler Wrappers
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Cray provides ``PrgEnv-<compiler>`` modules (e.g., ``PrgEnv-cray``) that load
+compatible components of a specific compiler toolchain. The components include
+the specified compiler as well as MPI, LibSci, and other libraries. Loading the
+``PrgEnv-<compiler>`` modules also defines a set of compiler wrappers for that
+compiler toolchain that automatically add include paths and link in libraries
+for Cray software. Compiler wrappers are provided for C (``cc``), C++ (``CC``),
+and Fortran (``ftn``).
+
+.. note::
+   Use the ``-craype-verbose`` flag to display the full include and link information used by the Cray compiler wrappers. This must be called on a file to see the full output (e.g., ``CC -craype-verbose test.cpp``).
+
+MPI
+---
+
+The MPI implementation available on Spock is Cray's MPICH, which is "GPU-aware"
+so GPU buffers can be passed directly to MPI calls.
+
+----
+
+Compiling
+=========
+
+This section covers how to compile for different programming models using the
+different compilers covered in the previous section.
+
+MPI
+---
+
++----------------+----------------+-----------------------------------------------------+-------------------------------------------------------------------------------+
+| Implementation | Module         | Compiler                                            | Header Files & Linking                                                        | 
++================+================+=====================================================+===============================================================================+
+| Cray MPICH     | ``cray-mpich`` | ``cc``, ``CC``, ``ftn`` (Cray compiler wrappers)    | MPI header files and linking is built into the Cray compiler wrappers         |
+|                |                +-----------------------------------------------------+-------------------------------------------------------------------------------+
+|                |                | ``hipcc``                                           | | ``-L$(MPICH_DIR)/lib -lmpi``                                                |
+|                |                |                                                     | | ``-I$(MPICH_DIR)/include``                                                  |
++----------------+----------------+-----------------------------------------------------+-------------------------------------------------------------------------------+
+
+
+GPU-Aware MPI
+^^^^^^^^^^^^^
+
+To use GPU-aware Cray MPICH, there are currently some extra steps needed in addition to the table above, which depend on the compiler that is used.
+
+1. Compiling with the Cray compiler wrappers, ``cc`` or ``CC``
+""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+To use GPU-aware Cray MPICH with the Cray compiler wrappers, users must load specific modules, set some environment variables, and include appropriate headers and libraries. The following modules and environment variables must be set:
+
+.. note:: 
+
+    Setting ``MPICH_SMP_SINGLE_COPY_MODE=CMA`` is required as a temporary workaround due to a `known issue <https://docs.olcf.ornl.gov/systems/spock_quick_start_guide.html#olcfdev-138-gpu-aware-cray-mpich-can-cause-hang-in-some-codes>`__. Users should make a note of where they set this environment variable (if e.g., set in a script) since it should NOT be set once the known issue has been resolved.
+
+.. code:: bash
+
+    module load craype-accel-amd-gfx908
+    module load PrgEnv-cray
+    module load rocm
+
+    ## These must be set before running
+    export MPIR_CVAR_GPU_EAGER_DEVICE_MEM=0
+    export MPICH_GPU_SUPPORT_ENABLED=1
+    export MPICH_SMP_SINGLE_COPY_MODE=CMA
+
+In addition, the following header files and libraries must be included:
+
+.. code:: bash
+
+    -I${ROCM_PATH}/include
+    -L${ROCM_PATH}/lib -lamdhip64 -lhsa-runtime64
+
+where the include path implies that ``#include <hip/hip_runtime.h>`` is included in the source file.
+
+2. Compiling with ``hipcc``
+"""""""""""""""""""""""""""
+
+To use GPU-aware Cray MPICH with ``hipcc``, users must load specific modules, set some environment variables, and include appropriate headers and libraries. The following modules and environment variables must be set:
+
+.. code:: bash
+
+    module load craype-accel-amd-gfx908
+    module load PrgEnv-cray
+    module load rocm
+
+    ## These must be set before running
+    export MPIR_CVAR_GPU_EAGER_DEVICE_MEM=0
+    export MPICH_GPU_SUPPORT_ENABLED=1
+    export MPICH_SMP_SINGLE_COPY_MODE=CMA
+
+In addition, the following header files and libraries must be included:
+
+.. code:: bash
+
+    -I${MPICH_DIR}/include
+    -L${MPICH_DIR}/lib -lmpi -L${CRAY_MPICH_ROOTDIR}/gtl/lib -lmpi_gtl_hsa
+
+
+OpenMP
+------
+
+This section shows how to compile with OpenMP using the different compilers
+covered above.
+
++--------+----------+-----------+-------------------------------------------+-------------------------------------+
+| Vendor | Module   | Language  | Compiler                                  | OpenMP flag (CPU thread)            |
++========+==========+===========+===========================================+=====================================+
+| Cray   | ``cce``  | C, C\+\+  | | ``cc``                                  | ``-fopenmp``                        |
+|        |          |           | | ``CC``                                  |                                     |
+|        |          +-----------+-------------------------------------------+-------------------------------------+
+|        |          | Fortran   | ``ftn``                                   | | ``-homp``                         | 
+|        |          |           |                                           | | ``-fopenmp`` (alias)              |
++--------+----------+-----------+-------------------------------------------+-------------------------------------+
+| AMD    | ``rocm`` | | C       | | ``$ROCM_PATH/llvm/bin/clang``           | ``-fopenmp``                        |
+|        |          | | C++     | | ``$ROCM_PATH/llvm/bin/clang++``         |                                     |
+|        |          | | Fortran | | ``ROCM_PATH/llvm/bin/flang``            |                                     |
++--------+----------+-----------+-------------------------------------------+-------------------------------------+
+| GCC    | ``gcc``  | | C       | | ``$GCC_PATH/bin/gcc``                   | ``-fopenmp``                        |
+|        |          | | C++     | | ``$GCC_PATH/bin/g++``                   |                                     |
+|        |          | | Fortran | | ``$GCC_PATH/bin/gfortran``              |                                     |
++--------+----------+-----------+-------------------------------------------+-------------------------------------+
+
+OpenMP GPU Offload
+------------------
+
+This section shows how to compile with OpenMP Offload using the different compilers covered above. 
+
+.. note::
+
+    Make sure the ``craype-accel-amd-gfx908`` module is loaded when using OpenMP offload.
+
++--------+----------+-----------+-------------------------------------------+----------------------------------------------+
+| Vendor | Module   | Language  | Compiler                                  | OpenMP flag (GPU)                            |
++========+==========+===========+===========================================+==============================================+
+| Cray   | ``cce``  | C         | | ``cc``                                  | ``-fopenmp``                                 |
+|        |          | C\+\+     | | ``CC``                                  |                                              |
+|        |          +-----------+-------------------------------------------+----------------------------------------------+
+|        |          | Fortran   | ``ftn``                                   | | ``-homp``                                  |
+|        |          |           |                                           | | ``-fopenmp`` (alias)                       |
++--------+----------+-----------+-------------------------------------------+----------------------------------------------+
+| AMD    | ``rocm`` | | C       | | ``$ROCM_PATH/llvm/bin/clang``           | | ``-fopenmp -target x86_64-pc-linux-gnu \`` |
+|        |          | | C\+\+   | | ``$ROCM_PATH/llvm/bin/clang++``         | | ``-fopenmp-targets=amdgcn-amd-amdhsa   \`` |
+|        |          | | Fortran | | ``ROCM_PATH/llvm/bin/flang``            | | ``-Xopenmp-target=amdgcn-amd-amdhsa    \`` |
+|        |          |           | | ``hipcc``                               | | ``-march=gfx908``                          |
++--------+----------+-----------+-------------------------------------------+----------------------------------------------+
+
+HIP
+---
+
+This section shows how to compile HIP codes using the Cray compiler wrappers and ``hipcc`` compiler driver.
+
+.. note::
+
+    Make sure the ``craype-accel-amd-gfx908`` module is loaded when using HIP.
+
++-----------+--------------------------------------------------------------------------------------------------------------------------+
+| Compiler  | Compile/Link Flags, Header Files, and Libraries                                                                          |
++===========+==========================================================================================================================+
+| ``CC``    | | ``CFLAGS = -std=c++11 -D__HIP_ROCclr__ -D__HIP_ARCH_GFX908__=1 --rocm-path=${ROCM_PATH} --offload-arch=gfx908 -x hip`` |
+|           | | ``LFLAGS = -std=c++11 -D__HIP_ROCclr__ --rocm-path=${ROCM_PATH}``                                                      |
+|           | | ``-I${HIP_PATH}/include``                                                                                              |
+|           | | ``-L${HIP_PATH}/lib -lamdhip64``                                                                                       |
++-----------+--------------------------------------------------------------------------------------------------------------------------+
+| ``hipcc`` | | Can be used directly to compile HIP source files.                                                                      |
+|           | | To see what is being invoked within this compiler driver, issue the command, ``hipcc --verbose``                       |
++-----------+--------------------------------------------------------------------------------------------------------------------------+
+
+----
+
+Running Jobs
+============
+
+This section describes how to run programs on the Spock compute nodes,
+including a brief overview of Slurm and also how to map processes and threads
+to CPU cores and GPUs.
+
+Slurm Workload Manager
+----------------------
+
+`Slurm <https://slurm.schedmd.com/>`__ is the workload manager used to interact
+with the compute nodes on Spock. In the following subsections, the most
+commonly used Slurm commands for submitting, running, and monitoring jobs will
+be covered, but users are encouraged to visit the official documentation and
+man pages for more information.
+
+Batch Scheduler and Job Launcher
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Slurm provides 3 ways of submitting and launching jobs on Spock's compute
+nodes: batch  scripts, interactive, and single-command. The Slurm commands
+associated with these methods are shown in the table below and examples of
+their use can be found in the related subsections.
+
++------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``sbatch`` | | Used to submit a batch script to allocate a Slurm job allocation. The script contains options preceded with ``#SBATCH``.                                                   |
+|            | | (see Batch Scripts section below)                                                                                                                                          |
++------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``salloc`` | | Used to allocate an interactive Slurm job allocation, where one or more job steps (i.e., ``srun`` commands) can then be launched on the allocated resources (i.e., nodes). |
+|            | | (see Interactive Jobs section below)                                                                                                                                       |
++------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+
+| ``srun``   | | Used to run a parallel job (job step) on the resources allocated with sbatch or ``salloc``.                                                                                |
+|            | | If necessary, srun will first create a resource allocation in which to run the parallel job(s).                                                                            |
+|            | | (see Single Command section below)                                                                                                                                         |
++------------+------------------------------------------------------------------------------------------------------------------------------------------------------------------------------+ 
+
+Batch Scripts
+"""""""""""""
+
+A batch script can be used to submit a job to run on the compute nodes at a
+later time. In this case, stdout and stderr will be written to a file(s) that
+can be opened after the job completes. Here is an example of a simple batch
+script:
+
+.. code-block:: bash
+   :linenos:
+
+   #!/bin/bash
+   #SBATCH -A <project_id>
+   #SBATCH -J <job_name>
+   #SBATCH -o %x-%j.out
+   #SBATCH -t 00:05:00
+   #SBATCH -p <partition> 
+   #SBATCH -N 2
+ 
+   srun -n4 --ntasks-per-node=2 ./a.out 
+
+The Slurm submission options are preceded by ``#SBATCH``, making them appear as
+comments to a shell (since comments begin with ``#``). Slurm will look for
+submission options from the first line through the first non-comment line.
+Options encountered after the first non-comment line will not be read by Slurm.
+In the example script, the lines are:
+
++------+-------------------------------------------------------------------------------+
+| Line | Description                                                                   |
++======+===============================================================================+ 
+| 1    | [Optional] shell interpreter line                                             |
++------+-------------------------------------------------------------------------------+ 
+| 2    | OLCF project to charge                                                        |
++------+-------------------------------------------------------------------------------+ 
+| 3    | Job name                                                                      |
++------+-------------------------------------------------------------------------------+ 
+| 4    | stdout file name ( ``%x`` represents job name, ``%j`` represents job id)      |
++------+-------------------------------------------------------------------------------+ 
+| 5    | Walltime requested (``HH:MM:SS``)                                             |
++------+-------------------------------------------------------------------------------+ 
+| 6    | Batch queue                                                                   |
++------+-------------------------------------------------------------------------------+ 
+| 7    | Number of compute nodes requested                                             |
++------+-------------------------------------------------------------------------------+ 
+| 8    | Blank line                                                                    |
++------+-------------------------------------------------------------------------------+
+| 9    | ``srun`` command to launch parallel job (requesting 4 processes - 2 per node) | 
++------+-------------------------------------------------------------------------------+
+
+.. _interactive-spock:
+
+Interactive Jobs
+""""""""""""""""
+
+To request an interactive job where multiple job steps (i.e., multiple srun
+commands) can be launched on the allocated compute node(s), the ``salloc``
+command can be used:
+
+.. code-block:: bash
+   
+   $ salloc -A <project_id> -J <job_name> -t 00:05:00 -p <partition> -N 2
+   salloc: Granted job allocation 4258
+   salloc: Waiting for resource configuration
+   salloc: Nodes spock[10-11] are ready for job
+ 
+   $ srun -n 4 --ntasks-per-node=2 ./a.out
+   <output printed to terminal>
+ 
+   $ srun -n 2 --ntasks-per-node=1 ./a.out
+   <output printed to terminal>
+   
+Here, ``salloc`` is used to request an allocation of 2 MI100 compute nodes for
+5 minutes. Once the resources become available, the user is granted access to
+the compute nodes (``spock10`` and ``spock11`` in this case) and can launch job
+steps on them using srun. 
+
+.. _single-command-spock:
+
+Single Command (non-interactive)
+""""""""""""""""""""""""""""""""
+
+.. code-block:: bash
+
+   $ srun -A <project_id> -t 00:05:00 -p <partition> -N 2 -n 4 --ntasks-per-node=2 ./a.out
+   <output printed to terminal>
+
+The job name and output options have been removed since stdout/stderr are
+typically desired in the terminal window in this usage mode.
+
+Common Slurm Submission Options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The table below summarizes commonly-used Slurm job submission options:
+
++--------------------------+--------------------------------+
+| ``A <project_id>``       | Project ID to charge           |
++--------------------------+--------------------------------+
+| ``-J <job_name>``        | Name of job                    |
++--------------------------+--------------------------------+
+| ``-p <partition>``       | Partition / batch queue        |
++--------------------------+--------------------------------+
+| ``-t <time>``            | Wall clock time <``HH:MM:SS``> |
++--------------------------+--------------------------------+
+| ``-N <number_of_nodes>`` | Number of compute nodes        |
++--------------------------+--------------------------------+
+| ``-o <file_name>``       | Standard output file name      |
++--------------------------+--------------------------------+
+| ``-e <file_name>``       | Standard error file name       |
++--------------------------+--------------------------------+
+
+For more information about these and/or other options, please see the
+``sbatch`` man page.
+
+Other Common Slurm Commands
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The table below summarizes commonly-used Slurm commands:
+
++--------------+---------------------------------------------------------------------------------------------------------------------------------+
+| ``sinfo``    | | Used to view partition and node information.                                                                                  |
+|              | | E.g., to view user-defined details about the caar queue:                                                                      |
+|              | | ``sinfo -p caar -o "%15N %10D %10P %10a %10c %10z"``                                                                          | 
++--------------+---------------------------------------------------------------------------------------------------------------------------------+
+| ``squeue``   | | Used to view job and job step information for jobs in the scheduling queue.                                                   |
+|              | | E.g., to see all jobs from a specific user:                                                                                   |
+|              | | ``squeue -l -u <user_id>``                                                                                                    |
++--------------+---------------------------------------------------------------------------------------------------------------------------------+
+| ``sacct``    | | Used to view accounting data for jobs and job steps in the job accounting log (currently in the queue or recently completed). |
+|              | | E.g., to see a list of specified information about all jobs submitted/run by a users since 1 PM on January 4, 2021:           |
+|              | | ``sacct -u <username> -S 2021-01-04T13:00:00 -o "jobid%5,jobname%25,user%15,nodelist%20" -X``                                 |
++--------------+---------------------------------------------------------------------------------------------------------------------------------+
+| ``scancel``  | | Used to signal or cancel jobs or job steps.                                                                                   |
+|              | | E.g., to cancel a job:                                                                                                        |
+|              | | ``scancel <jobid>``                                                                                                           | 
++--------------+---------------------------------------------------------------------------------------------------------------------------------+
+| ``scontrol`` | | Used to view or modify job configuration.                                                                                     |
+|              | | E.g., to place a job on hold:                                                                                                 |
+|              | | ``scontrol hold <jobid>``                                                                                                     |  
++--------------+---------------------------------------------------------------------------------------------------------------------------------+
+
+----
+
+Slurm Compute Node Partitions
+-----------------------------
+
+Spock's compute nodes are separated into 2 Slurm partitions (queues): 1 for
+CAAR projects and 1 for ECP projects. Please see the tables below for details.
+
+.. note::
+    If CAAR or ECP teams require a temporary exception to this policy, please
+    email help@olcf.ornl.gov with your request and it will be given to the OLCF
+    Resource Utilization Council (RUC) for review.
+
+CAAR Partition
+^^^^^^^^^^^^^^
+
+The CAAR partition consists of 24 total compute nodes. On a per-project basis,
+each user can have 1 running and 1 eligible job at a time, with no limit on the
+number of jobs submitted.
+
++-----------------+--------------+
+| Number of Nodes | Max Walltime |
++=================+==============+
+| 1 - 4           | 3 hours      |
++-----------------+--------------+
+| 5 - 16          | 1 hour       |
++-----------------+--------------+
+
+
+ECP Partition
+^^^^^^^^^^^^^
+
+The ECP partition consists of 12 total compute nodes. On a per-project basis,
+each user can have 1 running and 1 eligible job at a time, with up to 5 jobs
+submitted.
+
++-----------------+--------------+
+| Number of Nodes | Max Walltime |
++=================+==============+
+| 1 - 4           | 3 hours      |
++-----------------+--------------+
+
+Process and Thread Mapping
+--------------------------
+
+This section describes how to map processes (e.g., MPI ranks) and process threads (e.g., OpenMP threads) to the CPUs and GPUs on Spock. The :ref:`spock-compute-nodes` diagram will be helpful when reading this section to understand which hardware threads your processes and threads run on. 
+
+CPU Mapping
+^^^^^^^^^^^
+
+In this sub-section, a simple MPI+OpenMP "Hello, World" program (`hello_mpi_omp <https://code.ornl.gov/olcf/hello_mpi_omp>`__) will be used to clarify the mappings. Slurm's :ref:`interactive-spock` method was used to request an allocation of 1 compute node for these examples: ``salloc -A <project_id> -t 30 -p <parition> -N 1``
+
+The ``srun`` options used in this section are (see ``man srun`` for more information):
+
++----------------------------------+-------------------------------------------------------------------------------------------------------+
+| ``-c, --cpus-per-task=<ncpus>``  | | Request that ``ncpus`` be allocated per process (default is 1).                                     |
+|                                  | | (``ncpus`` refers to hardware threads)                                                              |
++----------------------------------+-------------------------------------------------------------------------------------------------------+
+| ``--threads-per-core=<threads>`` | | In task layout, use the specified maximum number of threads per core                                |
+|                                  | | (default is 1; there are 2 hardware threads per physical CPU core).                                 |
++----------------------------------+-------------------------------------------------------------------------------------------------------+
+|  ``--cpu-bind=threads``          | | Bind tasks to CPUs.                                                                                 |
+|                                  | | ``threads`` - Automatically generate masks binding tasks to threads.                                |
+|                                  | | (Although this option is not explicitly used in these examples, it is the default CPU binding.)     |
++----------------------------------+-------------------------------------------------------------------------------------------------------+
+
+.. note::
+
+    In the ``srun`` man page (and so the table above), threads refers to hardware threads.
+
+2 MPI ranks - each with 2 OpenMP threads
+""""""""""""""""""""""""""""""""""""""""
+
+In this example, the intent is to launch 2 MPI ranks, each of which spawn 2 OpenMP threads, and have all of the 4 OpenMP threads run on different physical CPU cores.
+
+**First (INCORRECT) attempt**
+
+To set the number of OpenMP threads spawned per MPI rank, the ``OMP_NUM_THREADS`` environment variable can be used. To set the number of MPI ranks launched, the ``srun`` flag ``-n`` can be used.
+
+.. code-block:: bash
+
+    $ export OMP_NUM_THREADS=2
+    $ srun -n2 ./hello_mpi_omp | sort
+
+    WARNING: Requested total thread count and/or thread affinity may result in
+    oversubscription of available CPU resources!  Performance may be degraded.
+    Explicitly set OMP_WAIT_POLICY=PASSIVE or ACTIVE to suppress this message.
+    Set CRAY_OMP_CHECK_AFFINITY=TRUE to print detailed thread-affinity messages.
+    WARNING: Requested total thread count and/or thread affinity may result in
+    oversubscription of available CPU resources!  Performance may be degraded.
+    Explicitly set OMP_WAIT_POLICY=PASSIVE or ACTIVE to suppress this message.
+    Set CRAY_OMP_CHECK_AFFINITY=TRUE to print detailed thread-affinity messages.
+
+    MPI 000 - OMP 000 - HWT 000 - Node spock01
+    MPI 000 - OMP 001 - HWT 000 - Node spock01
+    MPI 001 - OMP 000 - HWT 016 - Node spock01
+    MPI 001 - OMP 001 - HWT 016 - Node spock01
+
+The first thing to notice here is the ``WARNING`` about oversubscribing the available CPU cores. Also, the output shows each MPI rank did spawn 2 OpenMP threads, but both OpenMP threads ran on the same hardware thread (for a given MPI rank). This was not the intended behavior; each OpenMP thread was meant to run on its own physical CPU core.
+
+**Second (CORRECT) attempt**
+
+By default, each MPI rank is allocated only 1 hardware thread, so both OpenMP threads only have that 1 hardware thread to run on - hence the WARNING and undesired behavior. In order for each OpenMP thread to run on its own physical CPU core, each MPI rank should be given 2 hardware thread (``-c 2``) - since, by default, only 1 hardware thread per physical CPU core is enabled (this would need to be ``-c 4`` if ``--threads-per-core=2`` instead of the default of ``1``. The OpenMP threads will be mapped to unique physical CPU cores unless there are not enough physical CPU cores available, in which case the remaining OpenMP threads will share hardware threads and a WARNING will be issued as shown in the previous example.
+
+.. code-block:: bash
+
+    $ export OMP_NUM_THREADS=2
+    $ srun -n2 -c2 ./hello_mpi_omp | sort
+
+    MPI 000 - OMP 000 - HWT 000 - Node spock13
+    MPI 000 - OMP 001 - HWT 001 - Node spock13
+    MPI 001 - OMP 000 - HWT 016 - Node spock13
+    MPI 001 - OMP 001 - HWT 017 - Node spock13
+
+
+Now the output shows that each OpenMP thread ran on (one of the hardware threads of) its own physical CPU cores. More specifically (see the Spock Compute Node diagram), OpenMP thread 000 of MPI rank 000 ran on hardware thread 000 (i.e., physical CPU core 00), OpenMP thread 001 of MPI rank 000 ran on hardware thread 001 (i.e., physical CPU core 01), OpenMP thread 000 of MPI rank 001 ran on hardware thread 016 (i.e., physical CPU core 16), and OpenMP thread 001 of MPI rank 001 ran on hardware thread 017 (i.e., physical CPU core 17) - as expected.
+
+.. note::
+
+    There are many different ways users might choose to perform these mappings, so users are encouraged to clone the ``hello_mpi_omp`` program and test whether or not processes and threads are running where intended.
+
+GPU Mapping
+^^^^^^^^^^^
+
+In this sub-section, an MPI+OpenMP+HIP "Hello, World" program (`hello_jobstep <https://code.ornl.gov/olcf/hello_jobstep>`__) will be used to clarify the GPU mappings. Again, Slurm's :ref:`interactive-spock` method was used to request an allocation of 2 compute node for these examples: ``salloc -A <project_id> -t 30 -p <parition> -N 2``. The CPU mapping part of this example is very similar to the example used above in the CPU Mapping sub-section, so the focus here will be on the GPU mapping part.
+
+The following ``srun`` options will be used in the examples below. See ``man srun`` for a complete list of options and more information.
+
++------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
+| ``--gpus-per-task``                            | Specify the number of GPUs required for the job on each task to be spawned in the job's resource allocation. |
++------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
+| ``--gpu-bind=closest``                         | Binds each task to the GPU which is on the same NUMA domain as the CPU core the MPI rank is running on.      |
++------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
+| ``--gpu-bind=map_gpu:<list>``                  | Bind tasks to specific GPUs by setting GPU masks on tasks (or ranks) as specified where                      |
+|                                                | ``<list>`` is ``<gpu_id_for_task_0>,<gpu_id_for_task_1>,...``. If the number of tasks (or                    |
+|                                                | ranks) exceeds the number of elements in this list, elements in the list will be reused as                   |
+|                                                | needed starting from the beginning of the list. To simplify support for large task                           |
+|                                                | counts, the lists may follow a map with an asterisk and repetition count. (For example                       |
+|                                                | ``map_gpu:0*4,1*4``)                                                                                         |
++------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
+| ``--ntasks-per-gpu=<ntasks>``                  | Request that there are ntasks tasks invoked for every GPU.                                                   |
++------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
+| ``--distribution=<value>[:<value>][:<value>]`` | Specifies the distribution of MPI ranks across compute nodes, sockets (NUMA domains on Spock), and cores,    |
+|                                                | respectively. The default values are ``block:cyclic:cyclic``                                                 |
++------------------------------------------------+--------------------------------------------------------------------------------------------------------------+
+
+.. note::
+    In general, GPU mapping can be accomplished in different ways. For example, an application might map MPI ranks to GPUs programmatically within the code using, say, ``hipSetDevice``. In this case, since all GPUs on a node are available to all MPI ranks on that node by default, there might not be a need to map to GPUs using Slurm (just do it in the code). However, in another application, there might be a reason to make only a subset of GPUs available to the MPI ranks on a node. It is this latter case that the following examples refer to.
+
+Mapping 1 task per GPU
+""""""""""""""""""""""
+
+In the following examples, each MPI rank (and its OpenMP threads) will be mapped to a single GPU.
+
+**Example 1: 4 MPI ranks - each with 2 OpenMP threads and 1 GPU (single-node)**
+
+This example launches 4 MPI ranks (``-n4``), each with 2 physical CPU cores (``-c2``) to launch 2 OpenMP threads (``OMP_NUM_THREADS=2``) on. In addition, each MPI rank (and its 2 OpenMP threads) should have access to only 1 GPU. To accomplish the GPU mapping, two new ``srun`` options will be used:
+
+* ``--gpus-per-task`` specifies the number of GPUs required for the job on each task
+* ``--gpu-bind=closest`` binds each task to the GPU which is closest.
+
+.. note::
+    To further clarify, ``--gpus-per-task`` does not actually bind GPUs to MPI ranks. It allocates GPUs to the job step. The ``--gpu-bind=closest`` is what actually maps a specific GPU to each rank; namely, the "closest" one, which is the GPU on the same NUMA domain as the CPU core the MPI rank is running on (see the :ref:`spock-compute-nodes` section).
+
+.. note::
+    Without these additional flags, all MPI ranks would have access to all GPUs (which is the default behavior).
+
+.. code-block:: bash
+
+    $ export OMP_NUM_THREADS=2
+    $ srun -N1 -n4 -c2 --gpus-per-task=1 --gpu-bind=closest ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 000 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 000 - OMP 001 - HWT 001 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 001 - OMP 000 - HWT 016 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 001 - OMP 001 - HWT 017 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 002 - OMP 000 - HWT 032 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 002 - OMP 001 - HWT 033 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 003 - OMP 000 - HWT 048 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 003 - OMP 001 - HWT 049 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+
+The output contains different IDs associated with the GPUs so it is important to first describe these IDs before moving on. ``GPU_ID`` is the node-level (or global) GPU ID, which is labeled as one might expect from looking at a node diagram: 0, 1, 2, 3. ``RT_GPU_ID`` is the HIP runtime GPU ID, which can be thought of as each MPI rank's local GPU ID numbering (with zero-based indexing). So in the output above, each MPI rank has access to 1 unique GPU - where MPI 000 has access to GPU 0, MPI 001 has access to GPU 1, etc., but all MPI ranks show a HIP runtime GPU ID of 0. The reason is that each MPI rank only "sees" one GPU and so the HIP runtime labels it as "0", even though it might be global GPU ID 0, 1, 2, or 3. The GPU's bus ID is included to definitively show that different GPUs are being used. 
+
+Here is a summary of the different GPU IDs reported by the example program:
+
+* ``GPU_ID`` is the node-level (or global) GPU ID read from ``ROCR_VISIBLE_DEVICES``. If this environment variable is not set (either by the user or by Slurm), the value of ``GPU_ID`` will be set to ``N/A``.
+* ``RT_GPU_ID`` is the HIP runtime GPU ID (as reported from, say ``hipGetDevice``).
+* ``Bus_ID`` is the physical bus ID associated with the GPUs. Comparing the bus IDs is meant to definitively show that different GPUs are being used.
+
+So the job step (i.e., ``srun`` command) used above gave the desired output. Each MPI rank spawned 2 OpenMP threads and had access to a unique GPU. The ``--gpus-per-task=1`` allocated 1 GPU for each MPI rank and the ``--gpu-bind=closest`` ensured that the closest GPU to each rank was the one used.
+
+**Example 2: 8 MPI ranks - each with 2 OpenMP threads and 1 GPU (multi-node)**
+
+This example will extend Example 1 to run on 2 nodes. As the output shows, it is a very straightforward exercise of changing the number of nodes to 2 (``-N2``) and the number of MPI ranks to 8 (``-n8``).
+
+.. code-block:: bash
+
+    $ export OMP_NUM_THREADS=2
+    $ srun -N2 -n8 -c2 --gpus-per-task=1 --gpu-bind=closest ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 000 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 000 - OMP 001 - HWT 001 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 001 - OMP 000 - HWT 016 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 001 - OMP 001 - HWT 017 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 002 - OMP 000 - HWT 032 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 002 - OMP 001 - HWT 033 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 003 - OMP 000 - HWT 048 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 003 - OMP 001 - HWT 049 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 004 - OMP 000 - HWT 000 - Node spock14 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 004 - OMP 001 - HWT 001 - Node spock14 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 005 - OMP 000 - HWT 016 - Node spock14 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 005 - OMP 001 - HWT 017 - Node spock14 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 006 - OMP 000 - HWT 032 - Node spock14 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 006 - OMP 001 - HWT 033 - Node spock14 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 007 - OMP 000 - HWT 048 - Node spock14 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 007 - OMP 001 - HWT 049 - Node spock14 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+
+**Example 3: 4 MPI ranks - each with 2 OpenMP threads and 1 *specific* GPU (single-node)**
+
+This example will be very similar to Example 1, but instead of using ``--gpu-bind=closest`` to map each MPI rank to the closest GPU, ``--gpu-bind=map_gpu`` will be used to map each MPI rank to a *specific* GPU. The ``map_gpu`` option takes a comma-separated list of GPU IDs to specify how the MPI ranks are mapped to GPUs, where the form of the comma-separated list is ``<gpu_id_for_task_0>, <gpu_id_for_task_1>,...``.
+
+.. code:: bash
+
+    $ export OMP_NUM_THREADS=2
+    $ srun -N1 -n4 -c2 --gpus-per-task=1 --gpu-bind=map_gpu:0,1,2,3 ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 000 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 000 - OMP 001 - HWT 001 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 001 - OMP 000 - HWT 016 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 001 - OMP 001 - HWT 017 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 002 - OMP 000 - HWT 032 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 002 - OMP 001 - HWT 033 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 003 - OMP 000 - HWT 048 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 003 - OMP 001 - HWT 049 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+
+
+Here, the output is the same as the results from Example 1. This is because the 4 GPU IDs in the comma-separated list happen to specify the GPUs within the same NUMA domains that the MPI ranks are in. So MPI 000 is mapped to GPU 0, MPI 001 is mapped to GPU 1, etc.
+
+While this level of control over mapping MPI ranks to GPUs might be useful for some applications, it is always important to consider the implication of the mapping. For example, if the order of the GPU IDs in the ``map_gpu`` option is reversed, the MPI ranks and the GPUs they are mapped to would be in different NUMA domains, which could potentially lead to poorer performance.
+
+.. code:: bash
+
+    $ export OMP_NUM_THREADS=2
+    $ srun -N1 -n4 -c2 --gpus-per-task=1 --gpu-bind=map_gpu:3,2,1,0 ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 000 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 000 - OMP 001 - HWT 001 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 001 - OMP 000 - HWT 016 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 001 - OMP 001 - HWT 017 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 002 - OMP 000 - HWT 032 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 002 - OMP 001 - HWT 033 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 003 - OMP 000 - HWT 048 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 003 - OMP 001 - HWT 049 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+
+Here, notice that MPI 000 now maps to GPU 3, MPI 001 maps to GPU 2, etc., so the MPI ranks are not in the same NUMA domains as the GPUs they are mapped to.
+
+.. note::
+    Again, this particular example would NOT be a very good mapping of GPUs to MPI ranks though. E.g., notice that MPI rank 000 is running on NUMA node 0, whereas GPU 3 is on NUMA node 3. Again, see the :ref:`spock-compute-nodes` section for NUMA descriptions.
+
+**Example 4: 8 MPI ranks - each with 2 OpenMP threads and 1 *specific* GPU (multi-node)**
+
+Extending Examples 2 and 3 to run on 2 nodes is also a straightforward exercise by changing the number of nodes to 2 (``-N2``) and the number of MPI ranks to 8 (``-n8``).
+
+.. code:: bash
+
+    $ export OMP_NUM_THREADS=2
+    $ srun -N2 -n8 -c2 --gpus-per-task=1 --gpu-bind=map_gpu:0,1,2,3 ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 000 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 000 - OMP 001 - HWT 001 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 001 - OMP 000 - HWT 016 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 001 - OMP 001 - HWT 017 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 002 - OMP 000 - HWT 032 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 002 - OMP 001 - HWT 033 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 003 - OMP 000 - HWT 048 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 003 - OMP 001 - HWT 049 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 004 - OMP 000 - HWT 000 - Node spock14 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 004 - OMP 001 - HWT 001 - Node spock14 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 005 - OMP 000 - HWT 016 - Node spock14 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 005 - OMP 001 - HWT 017 - Node spock14 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 006 - OMP 000 - HWT 032 - Node spock14 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 006 - OMP 001 - HWT 033 - Node spock14 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 007 - OMP 000 - HWT 048 - Node spock14 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 007 - OMP 001 - HWT 049 - Node spock14 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+
+Mapping multiple MPI ranks to a single GPU
+""""""""""""""""""""""""""""""""""""""""""
+
+In the following examples, 2 MPI ranks will be mapped to 1 GPU. For the sake of brevity, ``OMP_NUM_THREADS`` will be set to ``1``, so ``-c1`` will be used unless otherwise specified.
+
+.. note::
+
+    On AMD's MI100 GPUs, multi-process service (MPS) is not needed since multiple MPI ranks per GPU is supported natively.
+
+**Example 5: 8 MPI ranks - where 2 ranks share a GPU (round-robin, single-node)**
+
+This example launches 8 MPI ranks (``-n8``), each with 1 physical CPU core (``-c1``) to launch 1 OpenMP thread (``OMP_NUM_THREADS=1``) on. The MPI ranks will be assigned to GPUs in a round-robin fashion so that each of the 4 GPUs on the node are shared by 2 MPI ranks. To accomplish this GPU mapping, a new ``srun`` option will be used:
+
+* ``--ntasks-per-gpu`` specifies the number of MPI ranks that will share access to a GPU.
+
+.. code:: bash
+
+    $ export OMP_NUM_THREADS=1
+    $ srun -N1 -n8 -c1 --ntasks-per-gpu=2 --gpu-bind=closest ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 000 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 001 - OMP 000 - HWT 016 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 002 - OMP 000 - HWT 032 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 003 - OMP 000 - HWT 048 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 004 - OMP 000 - HWT 001 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 005 - OMP 000 - HWT 017 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 006 - OMP 000 - HWT 033 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 007 - OMP 000 - HWT 049 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+
+The output shows the round-robin (``cyclic``) distribution of MPI ranks to GPUs. In fact, it is a round-robin distribution of MPI ranks *to NUMA domains* (the default distribution). The GPU mapping is a consequence of where the MPI ranks are distributed; ``--gpu-bind=closest`` simply maps the GPU in a NUMA domain to the MPI ranks in the same NUMA domain.
+
+**Example 6: 16 MPI ranks - where 2 ranks share a GPU (round-robin, multi-node)**
+
+This example is an extension of Example 5 to run on 2 nodes.
+
+.. warning::
+
+    This example requires a workaround to run as expected. ``--ntasks-per-gpu=2`` does not force MPI ranks 008-015 to run on the second node, so the number of physical CPU cores per MPI rank is increased to 8 (``-c8``) to force the desired behavior due to the constraint of the number of physical CPU cores (64) on a node.
+
+.. code:: bash
+
+    $ export OMP_NUM_THREADS=1
+    $ srun -N2 -n16 -c8 --ntasks-per-gpu=2 --gpu-bind=closest ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 005 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 001 - OMP 000 - HWT 018 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 002 - OMP 000 - HWT 032 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 003 - OMP 000 - HWT 050 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 004 - OMP 000 - HWT 010 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 005 - OMP 000 - HWT 026 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 006 - OMP 000 - HWT 040 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 007 - OMP 000 - HWT 059 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 008 - OMP 000 - HWT 003 - Node spock14 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 009 - OMP 000 - HWT 016 - Node spock14 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 010 - OMP 000 - HWT 032 - Node spock14 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 011 - OMP 000 - HWT 048 - Node spock14 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 012 - OMP 000 - HWT 008 - Node spock14 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 013 - OMP 000 - HWT 024 - Node spock14 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 014 - OMP 000 - HWT 042 - Node spock14 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 015 - OMP 000 - HWT 056 - Node spock14 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+
+**Example 7: 8 MPI ranks - where 2 ranks share a GPU (packed, single-node)**
+
+This example launches 8 MPI ranks (``-n8``), each with 8 physical CPU cores (``-c8``) to launch 1 OpenMP thread (``OMP_NUM_THREADS=1``) on. The MPI ranks will be assigned to GPUs in a packed fashion so that each of the 4 GPUs on the node are shared by 2 MPI ranks. Similar to Example 5, ``-ntasks-per-gpu=2`` will be used, but a new ``srun`` flag will be used to change the default round-robin (``cyclic``) distribution of MPI ranks across NUMA domains:
+
+* ``--distribution=<value>:[<value>]:[<value>]`` specifies the distribution of MPI ranks across compute nodes, sockets (NUMA domains on Spock), and cores, respectively. The default values are ``block:cyclic:cyclic``, which is where the ``cyclic`` assignment comes from in the previous examples.
+
+.. note::
+
+    In the job step for this example, ``--distribution=*:block`` is used, where ``*`` represents the default value of ``block`` for the distribution of MPI ranks across compute nodes and the distribution of MPI ranks across NUMA domains has been changed to ``block`` from its default value of ``cyclic``.
+
+.. note:: 
+
+    Because the distribution across NUMA domains has been changed to a "packed" (``block``) configuration, caution must be taken to ensure MPI ranks end up in the NUMA domains where the GPUs they intend to be mapped to are located. To accomplish this, the number of physical CPU cores assigned to an MPI rank was increased - in this case to 8. Doing so ensures that only 2 MPI ranks can fit into a single NUMA domain. If the value of ``-c`` was left at ``1``, all 8 MPI ranks would be "packed" into the first NUMA domain, where the "closest" GPU would be GPU 0 - the only GPU in that NUMA domain. 
+
+    Notice that this is not a workaround like in Example 6, but a requirement due to the ``block`` distribution of MPI ranks across NUMA domains.
+
+.. code:: bash
+
+    $ export OMP_NUM_THREADS=1
+    $ srun -N1 -n8 -c8 --ntasks-per-gpu=2 --gpu-bind=closest --distribution=*:block ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 001 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 001 - OMP 000 - HWT 008 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 002 - OMP 000 - HWT 016 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 003 - OMP 000 - HWT 024 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 004 - OMP 000 - HWT 035 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 005 - OMP 000 - HWT 043 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 006 - OMP 000 - HWT 049 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 007 - OMP 000 - HWT 057 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+
+The overall effect of using ``--distribution=*:block`` and increasing the number of physical CPU cores available to each MPI rank is to place the first two MPI ranks in NUMA 0 with GPU 0, the next two MPI ranks in NUMA 1 with GPU 1, and so on.
+
+**Example 8: 16 MPI ranks - where 2 ranks share a GPU (packed, multi-node)**
+
+This example is an extension of Example 7 to use 2 compute nodes. With the appropriate changes put in place in Example 7, it is a straightforward exercise to change to using 2 nodes (``-N2``) and 16 MPI ranks (``-n16``).
+
+.. code:: bash
+
+    $ export OMP_NUM_THREADS=1
+    $ srun -N2 -n16 -c8 --ntasks-per-gpu=2 --gpu-bind=closest --distribution=*:block ./hello_jobstep | sort
+
+    MPI 000 - OMP 000 - HWT 005 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 001 - OMP 000 - HWT 008 - Node spock13 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 002 - OMP 000 - HWT 017 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 003 - OMP 000 - HWT 026 - Node spock13 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 004 - OMP 000 - HWT 033 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 005 - OMP 000 - HWT 041 - Node spock13 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 006 - OMP 000 - HWT 048 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 007 - OMP 000 - HWT 057 - Node spock13 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 008 - OMP 000 - HWT 002 - Node spock14 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 009 - OMP 000 - HWT 011 - Node spock14 - RT_GPU_ID 0 - GPU_ID 0 - Bus_ID c9
+    MPI 010 - OMP 000 - HWT 016 - Node spock14 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 011 - OMP 000 - HWT 026 - Node spock14 - RT_GPU_ID 0 - GPU_ID 1 - Bus_ID 87
+    MPI 012 - OMP 000 - HWT 033 - Node spock14 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 013 - OMP 000 - HWT 041 - Node spock14 - RT_GPU_ID 0 - GPU_ID 2 - Bus_ID 48
+    MPI 014 - OMP 000 - HWT 054 - Node spock14 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+    MPI 015 - OMP 000 - HWT 063 - Node spock14 - RT_GPU_ID 0 - GPU_ID 3 - Bus_ID 09
+
+Multiple GPUs per MPI rank
+""""""""""""""""""""""""""
+
+As mentioned previously, all GPUs are accessible by all MPI ranks by default, so it is possible to *programatically* map any combination of MPI ranks to GPUs. However, there is currently no way to use Slurm to map multiple GPUs to a single MPI rank. If this functionality is needed for an application, please submit a ticket by emailing help@olcf.ornl.gov.
+
+
+.. note::
+
+    There are many different ways users might choose to perform these mappings, so users are encouraged to clone the ``hello_jobstep`` program and test whether or not processes and threads are running where intended.
+
+NVMe Usage
+----------
+
+Each Spock compute node has [2x] 3.2 TB NVMe devices (SSDs) with a peak sequential performance of 6900 MB/s (read) and 4200 MB/s (write). To use the NVMe, users must request access during job allocation using the ``-C nvme`` option to ``sbatch``, ``salloc``, or ``srun``. Once the devices have been granted to a job, users can access them at ``/mnt/bb/<userid>``. Users are responsible for moving data to/from the NVMe before/after their jobs. Here is a simple example script:
+
+.. code:: bash
+
+    #!/bin/bash
+    #SBATCH -A <projid>
+    #SBATCH -J nvme_test
+    #SBATCH -o %x-%j.out
+    #SBATCH -t 00:05:00
+    #SBATCH -p batch
+    #SBATCH -N 1
+    #SBATCH -C nvme
+    
+    date
+    
+    # Change directory to user scratch space (GPFS)
+    cd /gpfs/alpine/<projid>/scratch/<userid>
+    
+    echo " "
+    echo "*****ORIGINAL FILE*****"
+    cat test.txt
+    echo "***********************"
+    
+    # Move file from GPFS to SSD
+    mv test.txt /mnt/bb/<userid>
+    
+    # Edit file from compute node
+    srun -n1 hostname >> /mnt/bb/<userid>/test.txt
+    
+    # Move file from SSD back to GPFS
+    mv /mnt/bb/<userid>/test.txt .
+    
+    echo " "
+    echo "*****UPDATED FILE******"
+    cat test.txt
+    echo "***********************"
+
+And here is the output from the script:
+
+.. code:: bash
+
+    $ cat nvme_test-<jobid>.out
+    Mon May 17 12:28:18 EDT 2021
+    
+    *****ORIGINAL FILE*****
+    This is my file. There are many like it but this one is mine.
+    ***********************
+    
+    *****UPDATED FILE******
+    This is my file. There are many like it but this one is mine.
+    spock25
+    ***********************
+
+----
+
+Getting Help
+============
+
+If you have problems or need helping running on Spock, please submit a ticket
+by emailing help@olcf.ornl.gov.
+

--- a/systems/spock_quick_start_guide.rst
+++ b/systems/spock_quick_start_guide.rst
@@ -1,3 +1,4 @@
+:no-search:
 .. _spock-quick-start-guide:
 
 ***********************
@@ -5,11 +6,9 @@ Spock Quick-Start Guide
 ***********************
 
 .. warning::
-    **The Spock Early Access System was decommissioned on March 15, 2023.** The
-    file systems that were available on Spock are still accessible from the Home 
-    server and the Data Transfer Nodes (DTN), so all your data will remain accessible. 
-    If you do not have access to other OLCF systems, your project will move to data-only
-    for 30-days. If you have any questions, please contact help@olcf.ornl.gov.
+
+  This system was decommissioned on March 15, 2023 and is no longer online.
+  Information here is presented as an archive and is no longer updated.
 
 .. _spock-system-overview:
 

--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -1,0 +1,4614 @@
+.. _summit-user-guide:
+
+******************
+Summit User Guide
+******************
+
+.. note::
+
+  Notable changes to Summit for 2024 allocations:
+
+  Alpine Decomissioned (Jan 01, 2024)
+    Summit's previous scratch filesystem, Alpine, was decommissioned on January 01, 2024.
+
+  New Scratch Filesystem Available (Alpine2)
+    Alpine2, Summit's new GPFS scratch filesystem is now available to replace the previous scratch filesystem.  The new filesystem is mounted on Summit, Andes, and the DTNs.  Returning users will need to transfer data onto Apline2 since data on the previous scratch filesystem is no longer available.
+
+  Software Updates
+    Summit's software has been updated.  Returning users should recompile prior to running.  A list of default software updates can be found on https://docs.olcf.ornl.gov/software/software-news.html . Please note the previous software stack remains available and can be accessed by loading the DefApps-2023 modulefile. For convenience, a DefApps-2024 is also provide to restore the most recent version of packages.
+
+
+
+.. _summit-documentation-resources:
+
+Summit Documentation Resources
+==============================
+
+In addition to this Summit User Guide, there are other sources of
+documentation, instruction, and tutorials that could be useful for
+Summit users.
+
+The :ref:`OLCF Training Archive<training-archive>` provides a list of previous training
+events, including multi-day Summit Workshops. Some examples of topics addressed during
+these workshops include using Summit's NVME burst buffers, CUDA-aware MPI, advanced
+networking and MPI, and multiple ways of programming multiple GPUs per node. You can also
+find simple tutorials and code examples for some common programming and running tasks in
+our `Github tutorial page <https://github.com/olcf-tutorials>`_ .
+
+.. _system-overview:
+
+System Overview
+===============
+
+Summit is an IBM system located at the Oak Ridge Leadership Computing
+Facility. With a theoretical peak double-precision performance of
+approximately 200 PF, it is one of the most capable systems in the world
+for a wide range of traditional computational science applications. It
+is also one of the "smartest" computers in the world for deep learning
+applications with a mixed-precision capability in excess of 3 EF.
+
+.. _summit-nodes:
+
+Summit Nodes
+------------
+
+.. image:: /images/summit_node_architecture.png
+   :align: center
+   :alt: Summit node architecture diagram
+
+The basic building block of Summit is the IBM Power System AC922 node.
+Each of the approximately 4,600 compute nodes on Summit contains two IBM
+POWER9 processors and six `NVIDIA Tesla V100`_ accelerators and provides
+a theoretical double-precision capability of
+approximately 40 TF. Each POWER9 processor is connected via dual NVLINK
+bricks, each capable of a 25GB/s transfer rate in each direction.
+
+Most Summit nodes contain 512 GB of DDR4 memory for use by the POWER9
+processors, 96 GB of High Bandwidth Memory (HBM2) for use by the accelerators,
+and 1.6TB of non-volatile memory that can be used as a burst buffer. A small
+number of nodes (54) are configured as "high memory" nodes. These nodes contain 2TB of 
+DDR4 memory, 192GB of HBM2, and 6.4TB of non-volatile memory.
+
+The POWER9 processor is built around IBM’s SIMD
+Multi-Core (SMC). The processor provides 22 SMCs with separate 32kB L1
+data and instruction caches. Pairs of SMCs share a 512kB L2 cache and a
+10MB L3 cache. SMCs support Simultaneous Multi-Threading (SMT) up to a
+level of 4, meaning each physical core supports up to 4 :ref:`hardware-threads`.
+
+The POWER9 processors and V100
+accelerators are cooled with cold plate technology. The remaining
+components are cooled through more traditional methods, although exhaust
+is passed through a back-of-cabinet heat exchanger prior to being
+released back into the room. Both the cold plate and heat exchanger
+operate using medium temperature water which is more cost-effective for
+the center to maintain than chilled water used by older systems.
+
+Node Types
+----------
+
+On Summit, there are three major types of nodes you will encounter:
+Login, Launch, and Compute. While all of these are similar in terms of
+hardware (see: :ref:`summit-nodes`), they differ considerably in their intended
+use.
+
++-------------+----------------------------------------------------------------------------------+
+| Node Type   | Description                                                                      |
++=============+==================================================================================+
+| Login       | When you connect to Summit, you're placed on a login node. This                  |
+|             | is the place to write/edit/compile your code, manage data, submit jobs, etc. You |
+|             | should never launch parallel jobs from a login node nor should you run threaded  |
+|             | jobs on a login node. Login nodes are shared resources that are in use by many   |
+|             | users simultaneously.                                                            |
++-------------+----------------------------------------------------------------------------------+
+| Launch      | When your batch script (or interactive batch job) starts                         |
+|             | running, it will execute on a Launch Node. (If you were a user of Titan,         |
+|             | these are similar in function to service nodes on that system). All commands     |
+|             | within your job script (or the commands you run in an interactive job) will run  |
+|             | on a launch node. Like login nodes, these are shared resources so you should not |
+|             | run multiprocessor/threaded programs on Launch nodes. It is appropriate to       |
+|             | launch the jsrun command from launch nodes.                                      |
++-------------+----------------------------------------------------------------------------------+
+| Compute     | Most of the nodes on Summit are compute nodes. These are where                   |
+|             | your parallel job executes. They're accessed via the jsrun command.              |
++-------------+----------------------------------------------------------------------------------+
+
+Although the nodes are logically organized into different types, they
+all contain similar hardware. As a result of this homogeneous
+architecture there is not a need to cross-compile when building on a
+login node. Since login nodes have similar hardware resources as compute
+nodes, any tests that are run by your build process (especially by
+utilities such as ``autoconf`` and ``cmake``) will have access to the
+same type of hardware that is on compute nodes and should not require
+intervention that might be required on non-homogeneous systems.
+
+.. note::
+    Login nodes have (2) 16-core Power9 CPUs and (4) V100 GPUs.
+    Compute nodes have (2) 22-core Power9 CPUs and (6) V100 GPUs.
+
+System Interconnect
+-------------------
+
+Summit nodes are connected to a dual-rail EDR InfiniBand network
+providing a node injection bandwidth of 23 GB/s. Nodes are
+interconnected in a Non-blocking Fat Tree topology. This interconnect is
+a three-level tree implemented by a switch to connect nodes within each
+cabinet (first level) along with Director switches (second and third
+level) that connect cabinets together.
+
+File Systems
+------------
+
+Summit is connected to an IBM Spectrum Scale™ filesystem named Alpine2.
+Summit also has access to the center-wide NFS-based filesystem (which provides user and
+project home areas) and has access to the center’s Nearline archival storage system (Kronos) for user and project archival storage.
+
+Operating System
+----------------
+
+
+Summit is running Red Hat Enterprise Linux (RHEL) version 8.2.
+
+
+.. _hardware-threads:
+
+Hardware Threads
+----------------
+
+The IBM POWER9 processor supports Hardware Threads. Each of the POWER9’s
+physical cores has 4 “slices”. These slices provide Simultaneous Multi
+Threading (SMT) support within the core. Three SMT modes are supported:
+SMT4, SMT2, and SMT1. In SMT4 mode, each of the slices operates
+independently of the other three. This would permit four separate
+streams of execution (i.e. OpenMP threads or MPI tasks) on each physical
+core. In SMT2 mode, pairs of slices work together to run tasks. Finally,
+in SMT1 mode the four slices work together to execute the task/thread
+assigned to the physical core. Regardless of the SMT mode used, the four
+slices share the physical core’s L1 instruction & data caches.
+https://vimeo.com/283756938
+
+
+.. _gpus:
+
+GPUs
+----
+
+Each Summit Compute node has 6 NVIDIA V100 GPUs.  The NVIDIA Tesla V100
+accelerator has a peak performance of 7.8 TFLOP/s (double-precision) and
+contributes to a majority of the computational work performed on Summit. Each
+V100 contains 80 streaming multiprocessors (SMs), 16 GB (32 GB on high-memory
+nodes) of high-bandwidth memory (HBM2), and a 6 MB L2 cache that is available to
+the SMs. The GigaThread Engine is responsible for distributing work among the
+SMs and (8) 512-bit memory controllers control access to the 16 GB (32 GB on
+high-memory nodes) of HBM2 memory. The V100 uses NVIDIA's NVLink interconnect
+to pass data between GPUs as well as from CPU-to-GPU. We provide a more in-depth
+look into the `NVIDIA Tesla V100`_ later in the Summit Guide.
+
+
+
+
+
+.. _connecting:
+
+Connecting
+==========
+
+To connect to Summit, ssh to summit.olcf.ornl.gov. For example:
+
+::
+
+    ssh username@summit.olcf.ornl.gov
+
+For more information on connecting to OLCF resources, see :ref:`connecting-to-olcf`.
+
+Data and Storage
+==================
+
+For more information about center-wide file systems and data archiving available
+on Summit, please refer to the pages on :ref:`data-storage-and-transfers`.
+
+Each compute node on Summit has a 1.6TB \ **N**\ on-\ **V**\ olatile **Me**\
+mory (NVMe) storage device (high-memory nodes have a 6.4TB NVMe storage device), colloquially known as a "Burst Buffer" with
+theoretical performance peak of 2.1 GB/s for writing and 5.5 GB/s for reading.
+The NVMes could be used to reduce the time that applications wait for
+I/O.  More information can be found later in the `Burst Buffer`_ section.
+
+
+
+.. _software:
+
+Software
+========
+
+Visualization and analysis tasks should be done on the Andes cluster. There are a
+few tools provided for various visualization tasks, as described in the
+:ref:`andes-viz-tools` section of the :ref:`andes-user-guide`.
+
+For a full list of software available at the OLCF, please see the
+Software section (coming soon).
+
+.. _shell-programming-environments:
+
+Shell & Programming Environments
+================================
+
+OLCF systems provide many software packages and scientific
+libraries pre-installed at the system-level for users to take advantage
+of. To facilitate this, environment management tools are employed to
+handle necessary changes to the shell. The sections below provide
+information about using these management tools on Summit.
+
+Default Shell
+-------------
+
+A user’s default shell is selected when completing the User Account
+Request form. The chosen shell is set across all OLCF resources, and is
+the shell interface a user will be presented with upon login to any OLCF
+system. Currently, supported shells include:
+
+-  bash
+-  tcsh
+-  csh
+-  ksh
+
+If you would like to have your default shell changed, please contact the
+`OLCF User Assistance Center <https://www.olcf.ornl.gov/for-users/user-assistance/>`__ at
+help@nccs.gov.
+
+.. _environment-management-with-lmod:
+
+Environment Management with Lmod
+--------------------------------
+
+Environment modules are provided through `Lmod
+<https://lmod.readthedocs.io/en/latest/>`__, a Lua-based module system for
+dynamically altering shell environments. By managing changes to the shell’s
+environment variables (such as ``PATH``, ``LD_LIBRARY_PATH``, and
+``PKG_CONFIG_PATH``), Lmod allows you to alter the software available in your
+shell environment without the risk of creating package and version combinations
+that cannot coexist in a single environment.
+
+Lmod is a recursive environment module system, meaning it is aware of module
+compatibility and actively alters the environment to protect against conflicts.
+Messages to stderr are issued upon Lmod implicitly altering the environment.
+Environment modules are structured hierarchically by compiler family such that
+packages built with a given compiler will only be accessible if the compiler
+family is first present in the environment.
+
+.. note::
+    Lmod can interpret both Lua modulefiles and legacy Tcl
+    modulefiles. However, long and logic-heavy Tcl modulefiles may require
+    porting to Lua.
+
+General Usage
+^^^^^^^^^^^^^
+
+Typical use of Lmod is very similar to that of interacting with
+modulefiles on other OLCF systems. The interface to Lmod is provided by
+the ``module`` command:
+
++----------------------------------+-----------------------------------------------------------------------+
+| Command                          | Description                                                           |
++==================================+=======================================================================+
+| module -t list                   | Shows a terse list of the currently loaded modules.                   |
++----------------------------------+-----------------------------------------------------------------------+
+| module avail                     | Shows a table of the currently available modules                      |
++----------------------------------+-----------------------------------------------------------------------+
+| module help <modulename>         | Shows help information about <modulename>                             |
++----------------------------------+-----------------------------------------------------------------------+
+| module show <modulename>         | Shows the environment changes made by the <modulename> modulefile     |
++----------------------------------+-----------------------------------------------------------------------+
+| module spider <string>           | Searches all possible modules according to <string>                   |
++----------------------------------+-----------------------------------------------------------------------+
+| module load <modulename> [...]   | Loads the given <modulename>(s) into the current environment          |
++----------------------------------+-----------------------------------------------------------------------+
+| module use <path>                | Adds <path> to the modulefile search cache and ``MODULESPATH``        |
++----------------------------------+-----------------------------------------------------------------------+
+| module unuse <path>              | Removes <path> from the modulefile search cache and ``MODULESPATH``   |
++----------------------------------+-----------------------------------------------------------------------+
+| module purge                     | Unloads all modules                                                   |
++----------------------------------+-----------------------------------------------------------------------+
+| module reset                     | Resets loaded modules to system defaults                              |
++----------------------------------+-----------------------------------------------------------------------+
+| module update                    | Reloads all currently loaded modules                                  |
++----------------------------------+-----------------------------------------------------------------------+
+
+.. note::
+    Modules are changed recursively. Some commands, such as
+    ``module swap``, are available to maintain compatibility with scripts
+    using Tcl Environment Modules, but are not necessary since Lmod
+    recursively processes loaded modules and automatically resolves
+    conflicts.
+
+Searching for modules
+^^^^^^^^^^^^^^^^^^^^^
+
+Modules with dependencies are only available when the underlying dependencies,
+such as compiler families, are loaded. Thus, ``module avail`` will only display
+modules that are compatible with the current state of the environment. To search
+the entire hierarchy across all possible dependencies, the ``spider``
+sub-command can be used as summarized in the following table.
+
++----------------------------------------+------------------------------------------------------------------------------------+
+| Command                                | Description                                                                        |
++========================================+====================================================================================+
+| module spider                          | Shows the entire possible graph of modules                                         |
++----------------------------------------+------------------------------------------------------------------------------------+
+| module spider <modulename>             | Searches for modules named <modulename> in the graph of possible modules           |
++----------------------------------------+------------------------------------------------------------------------------------+
+| module spider <modulename>/<version>   | Searches for a specific version of <modulename> in the graph of possible modules   |
++----------------------------------------+------------------------------------------------------------------------------------+
+| module spider <string>                 | Searches for modulefiles containing <string>                                       |
++----------------------------------------+------------------------------------------------------------------------------------+
+
+ 
+
+Defining custom module collections
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Lmod supports caching commonly used collections of environment modules on a
+per-user basis in ``$HOME/.lmod.d``. To create a collection called "NAME" from
+the currently loaded modules, simply call ``module save NAME``. Omitting "NAME"
+will set the user’s default collection. Saved collections can be recalled and
+examined with the commands summarized in the following table.
+
++-------------------------+----------------------------------------------------------+
+| Command                 | Description                                              |
++=========================+==========================================================+
+| module restore NAME     | Recalls a specific saved user collection titled "NAME"   |
++-------------------------+----------------------------------------------------------+
+| module restore          | Recalls the user-defined defaults                        |
++-------------------------+----------------------------------------------------------+
+| module reset            | Resets loaded modules to system defaults                 |
++-------------------------+----------------------------------------------------------+
+| module restore system   | Recalls the system defaults                              |
++-------------------------+----------------------------------------------------------+
+| module savelist         | Shows the list user-defined saved collections            |
++-------------------------+----------------------------------------------------------+
+
+.. note::
+    You should use unique names when creating collections to
+    specify the application (and possibly branch) you are working on. For
+    example, ``app1-development``, ``app1-production``, and
+    ``app2-production``.
+
+.. note::
+    In order to avoid conflicts between user-defined collections
+    on multiple compute systems that share a home file system (e.g.
+    ``/ccs/home/[userid]``), lmod appends the hostname of each system to the
+    files saved in in your ``~/.lmod.d`` directory (using the environment
+    variable ``LMOD_SYSTEM_NAME``). This ensures that only collections
+    appended with the name of the current system are visible.
+
+The following screencast shows an example of setting up user-defined
+module collections on Summit. https://vimeo.com/293582400
+
+.. _compiling:
+
+Compiling
+=========
+
+Compilers
+---------
+
+Available Compilers
+^^^^^^^^^^^^^^^^^^^
+
+The following compilers are available on Summit:
+
+**XL:** IBM XL Compilers *(loaded by default)*
+
+**LLVM:** LLVM compiler infrastructure
+
+**PGI:** Portland Group compiler suite
+
+**NVHPC:** Nvidia HPC SDK compiler suite
+
+**GNU:** GNU Compiler Collection
+
+**NVCC**: CUDA C compiler
+
+PGI was bought out by Nvidia and have rebranded their compilers, incorporating
+them into the NVHPC compiler suite. There will be no more new releases of the 
+PGI compilers.
+
+Upon login, the default versions of the XL compiler suite and Spectrum Message
+Passing Interface (MPI) are added to each user's environment through the modules
+system. No changes to the environment are needed to make use of the defaults.
+
+Multiple versions of each compiler family are provided, and can be inspected
+using the modules system:
+
+::
+
+
+   summit$ module -t avail gcc
+   /sw/summit/spack-envs/base/modules/site/Core:
+   gcc/7.5.0
+   gcc/9.1.0
+   gcc/9.3.0
+   gcc/10.2.0
+   gcc/11.1.0
+
+
+
+C compilation
+^^^^^^^^^^^^^
+
+.. note::
+    type char is unsigned by default
+
++--------------+------------------+----------------+------------------+------------------+---------------------------+--------------------+
+| **Vendor**   | **Module**       | **Compiler**   |  **Enable C99**  | **Enable C11**   | **Default signed char**   | **Define macro**   |
+|              |                  |                |                  |                  |                           |                    |
++==============+==================+================+==================+==================+===========================+====================+
+| **IBM**      | ``xl``           | xlc xlc\_r     | ``-std=gnu99``   | ``-std=gnu11``   | ``-qchar=signed``         | ``-WF,-D``         |
++--------------+------------------+----------------+------------------+------------------+---------------------------+--------------------+
+| **GNU**      | system default   | gcc            | ``-std=gnu99``   | ``-std=gnu11``   | ``-fsigned-char``         | ``-D``             |
++--------------+------------------+----------------+------------------+------------------+---------------------------+--------------------+
+| **GNU**      | ``gcc``          | gcc            | ``-std=gnu99``   | ``-std=gnu11``   | ``-fsigned-char``         | ``-D``             |
++--------------+------------------+----------------+------------------+------------------+---------------------------+--------------------+
+| **LLVM**     | ``llvm``         | clang          | default          | ``-std=gnu11``   | ``-fsigned-char``         | ``-D``             |
++--------------+------------------+----------------+------------------+------------------+---------------------------+--------------------+
+| **PGI**      | ``pgi``          | pgcc           | ``-c99``         | ``-c11``         | ``-Mschar``               | ``-D``             |
++--------------+------------------+----------------+------------------+------------------+---------------------------+--------------------+
+| **NVHPC**    | ``nvhpc``        | nvc            | ``-c99``         | ``-c11``         | ``-Mschar``               | ``-D``             |
++--------------+------------------+----------------+------------------+------------------+---------------------------+--------------------+
+
+C++ compilations
+^^^^^^^^^^^^^^^^
+
+.. note::
+    type char is unsigned by default
+
++--------------+------------------+-------------------+--------------------------------+--------------------------------+---------------------------+--------------------+
+| **Vendor**   | **Module**       | **Compiler**      | **Enable C++11**               | **Enable C++14**               | **Default signed char**   | **Define macro**   |
+|              |                  |                   |                                |                                |                           |                    |
++==============+==================+===================+================================+================================+===========================+====================+
+| **IBM**      | ``xl``           | xlc++, xlc++\_r   | ``-std=gnu++11``               | ``-std=gnu++1y`` (PARTIAL)*    | ``-qchar=signed``         | ``-WF,-D``         |
++--------------+------------------+-------------------+--------------------------------+--------------------------------+---------------------------+--------------------+
+| **GNU**      | system default   | g++               | ``-std=gnu++11``               | ``-std=gnu++1y``               | ``-fsigned-char``         | ``-D``             |
++--------------+------------------+-------------------+--------------------------------+--------------------------------+---------------------------+--------------------+
+| **GNU**      | ``gcc``          | g++               | ``-std=gnu++11``               | ``-std=gnu++1y``               | ``-fsigned-char``         | ``-D``             |
++--------------+------------------+-------------------+--------------------------------+--------------------------------+---------------------------+--------------------+
+| **LLVM**     | ``llvm``         | clang++           | ``-std=gnu++11``               | ``-std=gnu++1y``               | ``-fsigned-char``         | ``-D``             |
++--------------+------------------+-------------------+--------------------------------+--------------------------------+---------------------------+--------------------+
+| **PGI**      | ``pgi``          | pgc++             | ``-std=c++11 -gnu_extensions`` | ``-std=c++14 -gnu_extensions`` | ``-Mschar``               | ``-D``             |
++--------------+------------------+-------------------+--------------------------------+--------------------------------+---------------------------+--------------------+
+| **NVHPC**    | ``nvhpc``        | nvc++             | ``-std=c++11 -gnu_extensions`` | ``-std=c++14 -gnu_extensions`` | ``-Mschar``               | ``-D``             |
++--------------+------------------+-------------------+--------------------------------+--------------------------------+---------------------------+--------------------+
+
+Fortran compilation
+^^^^^^^^^^^^^^^^^^^
+
++--------------+------------------+-----------------------------------+--------------------------+---------------------------+--------------------------+--------------------+
+| **Vendor**   | **Module**       | **Compiler**                      | **Enable F90**           | **Enable F2003**          | **Enable F2008**         | **Define macro**   |
+|              |                  |                                   |                          |                           |                          |                    |
++==============+==================+===================================+==========================+===========================+==========================+====================+
+| **IBM**      | ``xl``           | xlf xlf90 xlf95 xlf2003 xlf2008   | ``-qlanglvl=90std``      | ``-qlanglvl=2003std``     | ``-qlanglvl=2008std``    | ``-WF,-D``         |
++--------------+------------------+-----------------------------------+--------------------------+---------------------------+--------------------------+--------------------+
+| **GNU**      | system default   | gfortran                          | ``-std=f90``             | ``-std=f2003``            | ``-std=f2008``           | ``-D``             |
++--------------+------------------+-----------------------------------+--------------------------+---------------------------+--------------------------+--------------------+
+| **LLVM**     | ``llvm``         | xlflang                           | n/a                      | n/a                       | n/a                      | ``-D``             |
++--------------+------------------+-----------------------------------+--------------------------+---------------------------+--------------------------+--------------------+
+| **PGI**      | ``pgi``          | pgfortran                         | use ``.F90`` source file |  use ``.F03`` source file | use ``.F08`` source file | ``-D``             |
+|              |                  |                                   | suffix                   |  suffix                   | suffix                   |                    |
++--------------+------------------+-----------------------------------+--------------------------+---------------------------+--------------------------+--------------------+
+| **NVHPC**    | ``nvhpc``        | nvfortran                         | use ``.F90`` source file |  use ``.F03`` source file | use ``.F08`` source file | ``-D``             |
+|              |                  |                                   | suffix                   |  suffix                   | suffix                   |                    |
++--------------+------------------+-----------------------------------+--------------------------+---------------------------+--------------------------+--------------------+
+
+.. note::
+    The xlflang module currently conflicts with the clang
+    module. This restriction is expected to be lifted in future releases.
+
+MPI
+^^^
+
+MPI on Summit is provided by IBM Spectrum MPI. Spectrum MPI provides compiler
+wrappers that automatically choose the proper compiler to build your
+application.
+
+The following compiler wrappers are available:
+
+**C**: ``mpicc``
+
+**C++**: ``mpic++``, ``mpiCC``
+
+**Fortran**: ``mpifort``, ``mpif77``, ``mpif90``
+
+While these wrappers conveniently abstract away linking of Spectrum MPI, it's
+sometimes helpful to see exactly what's happening when invoked. The ``--showme``
+flag will display the full link lines, without actually compiling:
+
+::
+
+    summit$ mpicc --showme
+    /sw/summit/xl/16.1.1-10/xlC/16.1.1/bin/xlc_r -I/sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/xl-16.1.1-10/spectrum-mpi-10.4.0.3-20210112-v7qymniwgi6mtxqsjd7p5jxinxzdkhn3/include -pthread -L/sw/summit/spack-envs/base/opt/linux-rhel8-ppc64le/xl-16.1.1-10/spectrum-mpi-10.4.0.3-20210112-v7qymniwgi6mtxqsjd7p5jxinxzdkhn3/lib -lmpiprofilesupport -lmpi_ibm
+
+OpenMP
+^^^^^^
+
+.. note::
+    When using OpenMP with IBM XL compilers, the thread-safe
+    compiler variant is required; These variants have the same name as the
+    non-thread-safe compilers with an additional ``_r`` suffix. e.g. to
+    compile OpenMPI C code one would use ``xlc_r``
+
+.. note::
+    OpenMP offloading support is still under active development.
+    Performance and debugging capabilities in particular are expected to
+    improve as the implementations mature.
+
++---------------+-------------------+---------------------+-------------------+---------------------------------------------------------------------------------+
+| **Vendor**    | **3.1 Support**   | **Enable OpenMP**   | **4.x Support**   | **Enable OpenMP 4.x Offload**                                                   |
++===============+===================+=====================+===================+=================================================================================+
+| **IBM**       | FULL              | ``-qsmp=omp``       | FULL              | ``-qsmp=omp -qoffload``                                                         |
++---------------+-------------------+---------------------+-------------------+---------------------------------------------------------------------------------+
+| **GNU**       | FULL              | ``-fopenmp``        | PARTIAL           | ``-fopenmp``                                                                    |
++---------------+-------------------+---------------------+-------------------+---------------------------------------------------------------------------------+
+| **clang**     | FULL              | ``-fopenmp``        | PARTIAL           | ``-fopenmp -fopenmp-targets=nvptx64-nvidia-cuda --cuda-path=${OLCF_CUDA_ROOT}`` |
++---------------+-------------------+---------------------+-------------------+---------------------------------------------------------------------------------+
+| **xlflang**   | FULL              | ``-fopenmp``        | PARTIAL           | ``-fopenmp -fopenmp-targets=nvptx64-nvidia-cuda``                               |
++---------------+-------------------+---------------------+-------------------+---------------------------------------------------------------------------------+
+| **PGI**       | FULL              | ``-mp``             | NONE              | NONE                                                                            |
++---------------+-------------------+---------------------+-------------------+---------------------------------------------------------------------------------+
+| **NVHPC**     | FULL              | ``-mp=gpu``         | NONE              | NONE                                                                            |
++---------------+-------------------+---------------------+-------------------+---------------------------------------------------------------------------------+
+
+OpenACC
+^^^^^^^
+
++--------------+--------------------+-----------------------+---------------------------+
+| **Vendor**   | **Module**         | **OpenACC Support**   | **Enable OpenACC**        |
++==============+====================+=======================+===========================+
+| **IBM**      | ``xl``             | NONE                  | NONE                      |
++--------------+--------------------+-----------------------+---------------------------+
+| **GNU**      | system default     | NONE                  | NONE                      |
++--------------+--------------------+-----------------------+---------------------------+
+| **GNU**      | ``gcc``            | 2.5                   | ``-fopenacc``             |
++--------------+--------------------+-----------------------+---------------------------+
+| **LLVM**     | ``clang`` or       |                       |                           |
+|              | ``xlflang``        | NONE                  | NONE                      |
++--------------+--------------------+-----------------------+---------------------------+
+| **PGI**      | ``pgi``            | 2.5                   | ``-acc, -ta=nvidia:cc70`` |
++--------------+--------------------+-----------------------+---------------------------+
+| **NVHPC**    | ``nvhpc``          | 2.5                   | ``-acc=gpu -gpu=cc70``    |
++--------------+--------------------+-----------------------+---------------------------+
+
+CUDA compilation
+^^^^^^^^^^^^^^^^
+
+NVIDIA
+""""""
+
+CUDA C/C++ support is provided through the ``cuda`` module or throught the ``nvhpc`` module.
+
+``nvcc`` : Primary CUDA C/C++ compiler
+
+**Language support**
+
+``-std=c++11`` : provide C++11 support
+
+``--expt-extended-lambda`` : provide experimental host/device lambda support
+
+``--expt-relaxed-constexpr`` : provide experimental host/device constexpr support
+
+**Compiler support**
+
+NVCC currently supports XL, GCC, and PGI C++ backends.
+
+``--ccbin`` : set to host compiler location
+
+CUDA Fortran compilation
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+IBM
+"""
+
+The IBM compiler suite is made available through the default loaded xl
+module, the cuda module is also required.
+
+``xlcuf`` : primary Cuda fortran compiler, thread safe
+
+**Language support flags**
+
+``-qlanglvl=90std`` : provide Fortran90 support
+
+``-qlanglvl=95std`` : provide Fortran95 support
+
+``-qlanglvl=2003std`` : provide Fortran2003 support
+
+``-qlanglvl=2008std`` : provide Fortran2003 support
+
+PGI
+"""
+
+The PGI compiler suite is available through the ``pgi`` module.
+
+``pgfortran`` : Primary fortran compiler with CUDA Fortran support
+
+**Language support:**
+
+Files with ``.cuf`` suffix automatically compiled with cuda fortran support
+
+Standard fortran suffixed source files determines the standard involved,
+see the man page for full details
+
+``-Mcuda`` : Enable CUDA Fortran on provided source file
+
+Linking in Libraries
+--------------------
+
+OLCF systems provide many software packages and scientific
+libraries pre-installed at the system-level for users to take advantage
+of. In order to link these libraries into an application, users must
+direct the compiler to their location. The ``module show`` command can
+be used to determine the location of a particular library. For example
+
+::
+
+    summit$ module show essl
+    ------------------------------------------------------------------------------------
+       /sw/summit/modulefiles/core/essl/6.1.0-1:
+    ------------------------------------------------------------------------------------
+    whatis("ESSL 6.1.0-1 ")
+    prepend_path("LD_LIBRARY_PATH","/sw/summit/essl/6.1.0-1/essl/6.1/lib64")
+    append_path("LD_LIBRARY_PATH","/sw/summit/xl/16.1.1-beta4/lib")
+    prepend_path("MANPATH","/sw/summit/essl/6.1.0-1/essl/6.1/man")
+    setenv("OLCF_ESSL_ROOT","/sw/summit/essl/6.1.0-1/essl/6.1")
+    help([[ESSL 6.1.0-1
+
+    ]])
+
+When this module is loaded, the ``$OLCF_ESSL_ROOT`` environment variable
+holds the path to the ESSL installation, which contains the lib64/ and
+include/ directories:
+
+::
+
+    summit$ module load essl
+    summit$ echo $OLCF_ESSL_ROOT
+    /sw/summit/essl/6.1.0-1/essl/6.1
+    summit$ ls $OLCF_ESSL_ROOT
+    FFTW3  READMES  REDIST.txt  include  iso-swid  ivps  lap  lib64  man  msg
+
+The following screencast shows an example of linking two libraries into
+a simple program on Summit. https://vimeo.com/292015868
+
+.. _running-jobs:
+
+Running Jobs
+============
+
+As is the case on other OLCF systems, computational work on Summit is
+performed within jobs. A typical job consists of several components:
+
+-  A submission script
+-  An executable
+-  Input files needed by the executable
+-  Output files created by the executable
+
+In general, the process for running a job is to:
+
+#. Prepare executables and input files
+#. Write the batch script
+#. Submit the batch script
+#. Monitor the job's progress before and during execution
+
+The following sections will provide more information regarding running
+jobs on Summit. Summit uses IBM Spectrum Load Sharing Facility (LSF) as
+the batch scheduling system.
+
+.. _login-launch-and-compute-nodes:
+
+Login, Launch, and Compute Nodes
+--------------------------------
+
+Recall from the :ref:`system-overview`
+section that Summit has three types of nodes: login, launch, and
+compute. When you log into the system, you are placed on a login node.
+When your :ref:`batch-scripts` or :ref:`interactive-jobs` run,
+the resulting shell will run on a launch node. Compute nodes are accessed
+via the ``jsrun`` command. The ``jsrun`` command should only be issued
+from within an LSF job (either batch or interactive) on a launch node.
+Otherwise, you will not have any compute nodes allocated and your parallel
+job will run on the login node. If this happens, your job will interfere with
+(and be interfered with by) other users' login node tasks. ``jsrun`` is covered
+in-depth in the `Job Launcher (jsrun)`_ section.
+
+Per-User Login Node Resource Limits
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Because the login nodes are resources shared by all Summit users, we utilize
+``cgroups`` to help better ensure resource availability for all users of the
+shared nodes. By default each user is limited to **16 hardware-threads**, **16GB
+of memory**, and **1 GPU**.  Please note that limits are set per user and not
+individual login sessions. All user processes on a node are contained within a
+single cgroup and share the cgroup's limits.
+
+If a process from any of a user’s login sessions reaches 4 hours of CPU-time,
+all login sessions will be limited to **.5 hardware-thread**. After 8 hours of
+CPU-time, the process is automatically killed. To reset the cgroup limits on a
+node to default once the 4 hour CPU-time reduction has been reached, kill the
+offending process and start a new login session to the node.
+
+Users can run command ``check_cgroup_user`` on login nodes to check what processes 
+were recently killed by cgroup limits.
+
+    .. note:: Login node limits are set per user and not per individual login
+        session.  All user processes on a node are contained within a single cgroup
+        and will share the cgroup's limits.
+
+
+.. _batch-scripts:
+
+Batch Scripts
+-------------
+
+The most common way to interact with the batch system is via batch jobs.
+A batch job is simply a shell script with added directives to request
+various resources from or provide certain information to the batch
+scheduling system. Aside from the lines containing LSF options, the
+batch script is simply the series commands needed to set up and run your
+job.
+
+To submit a batch script, use the bsub command: ``bsub myjob.lsf``
+
+If you’ve previously used LSF, you’re probably used to submitting a job
+with input redirection (i.e. ``bsub < myjob.lsf``). This is not needed
+(and will not work) on Summit.
+
+As an example, consider the following batch script:
+
+.. code-block:: bash
+   :linenos:
+
+   #!/bin/bash
+   # Begin LSF Directives
+   #BSUB -P ABC123
+   #BSUB -W 3:00
+   #BSUB -nnodes 2048
+   #BSUB -alloc_flags gpumps
+   #BSUB -J RunSim123
+   #BSUB -o RunSim123.%J
+   #BSUB -e RunSim123.%J
+
+   cd $MEMBERWORK/abc123
+   cp $PROJWORK/abc123/RunData/Input.123 ./Input.123
+   date
+   jsrun -n 4092 -r 2 -a 12 -g 3 ./a.out
+   cp my_output_file /ccs/proj/abc123/Output.123
+
+.. note:: 
+   For Moderate Enhanced Projects, job scripts need to add "-l" ("ell") to the shell specification, similar to interactive usage.
+
++----------+------------+--------------------------------------------------------------------------------------------+
+| Line #   | Option     | Description                                                                                |
++==========+============+============================================================================================+
+| 1        |            | Shell specification. This script will run under with bash as the shell. Moderate enhanced  |
+|          |            | projects should add ``-l`` ("ell") to the shell specification.                             |
++----------+------------+--------------------------------------------------------------------------------------------+
+| 2        |            | Comment line                                                                               |
++----------+------------+--------------------------------------------------------------------------------------------+
+| 3        | Required   | This job will charge to the ABC123 project                                                 |
++----------+------------+--------------------------------------------------------------------------------------------+
+| 4        | Required   | Maximum walltime for the job is 3 hours                                                    |
++----------+------------+--------------------------------------------------------------------------------------------+
+| 5        | Required   | The job will use 2,048 compute nodes                                                       |
++----------+------------+--------------------------------------------------------------------------------------------+
+| 6        | Optional   | Enable GPU Multi-Process Service                                                           |
++----------+------------+--------------------------------------------------------------------------------------------+
+| 7        | Optional   | The name of the job is RunSim123                                                           |
++----------+------------+--------------------------------------------------------------------------------------------+
+| 8        | Optional   | Write standard output to a file named RunSim123.#, where # is the job ID assigned by LSF   |
++----------+------------+--------------------------------------------------------------------------------------------+
+| 9        | Optional   | Write standard error to a file named RunSim123.#, where # is the job ID assigned by LSF    |
++----------+------------+--------------------------------------------------------------------------------------------+
+| 10       | -          | Blank line                                                                                 |
++----------+------------+--------------------------------------------------------------------------------------------+
+| 11       | -          | Change into one of the scratch filesystems                                                 |
++----------+------------+--------------------------------------------------------------------------------------------+
+| 12       | -          | Copy input files into place                                                                |
++----------+------------+--------------------------------------------------------------------------------------------+
+| 13       | -          | Run the ``date`` command to write a timestamp to the standard output file                  |
++----------+------------+--------------------------------------------------------------------------------------------+
+| 14       | -          | Run the executable on the allocated compute nodes                                          |
++----------+------------+--------------------------------------------------------------------------------------------+
+| 15       | -          | Copy output files from the scratch area into a more permanent location                     |
++----------+------------+--------------------------------------------------------------------------------------------+
+
+.. _interactive-jobs:
+
+Interactive Jobs
+----------------
+
+Most users will find batch jobs to be the easiest way to interact with
+the system, since they permit you to hand off a job to the scheduler and
+then work on other tasks; however, it is sometimes preferable to run
+interactively on the system. This is especially true when developing,
+modifying, or debugging a code.
+
+Since all compute resources are managed/scheduled by LSF, it is not possible
+to simply log into the system and begin running a parallel code interactively.
+You must request the appropriate resources from the system and, if necessary,
+wait until they are available. This is done with an “interactive batch” job.
+Interactive batch jobs are submitted via the command line, which
+supports the same options that are passed via ``#BSUB`` parameters in a
+batch script. The final options on the command line are what makes the
+job “interactive batch”: ``-Is`` followed by a shell name. For example,
+to request an interactive batch job (with bash as the shell) equivalent
+to the sample batch script above, you would use the command:
+``bsub -W 3:00 -nnodes 2048 -P ABC123 -Is /bin/bash``
+
+
+As pointed out in :ref:`login-launch-and-compute-nodes`, you will be placed on
+a launch (a.k.a. "batch") node upon launching an interactive job and as usual
+need to use ``jsrun`` to access the compute node(s):
+
+.. code::
+
+    $ bsub -Is -W 0:10 -nnodes 1 -P STF007 $SHELL
+    Job <779469> is submitted to default queue <batch>.
+    <<Waiting for dispatch ...>>
+    <<Starting on batch2>>
+
+    $ hostname
+    batch2
+
+    $ jsrun -n1 hostname
+    a35n03
+
+Common bsub Options
+-------------------
+
+The table below summarizes options for submitted jobs. Unless otherwise
+noted, these can be used from batch scripts or interactive jobs. For
+interactive jobs, the options are simply added to the ``bsub`` command
+line. For batch scripts, they can either be added on the ``bsub``
+command line or they can appear as a ``#BSUB`` directive in the batch
+script. If conflicting options are specified (i.e. different walltime
+specified on the command line versus in the script), the option on the
+command line takes precedence. Note that LSF has numerous options; only
+the most common ones are described here. For more in-depth information
+about other LSF options, see the ``bsub`` man page.
+
+.. table::
+    :widths: 12 25 63
+
+    +--------------------+----------------------------------------+----------------------------------------------------------------------------------+
+    | Option             | Example Usage                          | Description                                                                      |
+    +====================+========================================+==================================================================================+
+    | ``-W``             | ``#BSUB -W 50``                        | Requested                                                                        |
+    |                    |                                        | maximum walltime. NOTE: The format is [hours:]minutes, not                       |
+    |                    |                                        | [[hours:]minutes:]seconds like PBS/Torque/Moab                                   |
+    +--------------------+----------------------------------------+----------------------------------------------------------------------------------+
+    | ``-nnodes``        | ``#BSUB -nnodes 1024``                 | Number of nodes                                                                  |
+    |                    |                                        | NOTE: There is specified with only one hyphen (i.e. -nnodes, not --nnodes)       |
+    +--------------------+----------------------------------------+----------------------------------------------------------------------------------+
+    | ``-P``             | ``#BSUB -P ABC123``                    | Specifies the                                                                    |
+    |                    |                                        | project to which the job should be charged                                       |
+    +--------------------+----------------------------------------+----------------------------------------------------------------------------------+
+    | ``-o``             | ``#BSUB -o jobout.%J``                 | File into which                                                                  |
+    |                    |                                        | job STDOUT should be directed (%J will be replaced with the job ID number) If    |
+    |                    |                                        | you do not also specify a STDERR file with ``-e`` or ``-eo``, STDERR will also   |
+    |                    |                                        | be written to this file.                                                         |
+    +--------------------+----------------------------------------+----------------------------------------------------------------------------------+
+    | ``-e``             | ``#BSUB -e jobout.%J``                 | File into which                                                                  |
+    |                    |                                        | job STDERR should be directed (%J will be replaced with the job ID number)       |
+    +--------------------+----------------------------------------+----------------------------------------------------------------------------------+
+    | ``-J``             | ``#BSUB -J MyRun123``                  | Specifies the                                                                    |
+    |                    |                                        | name of the job (if not present, LSF will use the name of the job script as the  |
+    |                    |                                        | job’s name)                                                                      |
+    +--------------------+----------------------------------------+----------------------------------------------------------------------------------+
+    | ``-w``             | ``#BSUB -w ended()``                   | Place a dependency on the job                                                    |
+    +--------------------+----------------------------------------+----------------------------------------------------------------------------------+
+    | ``-N``             | ``#BSUB -N``                           | Send a job report via email when the job completes                               |
+    +--------------------+----------------------------------------+----------------------------------------------------------------------------------+
+    | ``-XF``            | ``#BSUB -XF``                          | Use X11 forwarding                                                               |
+    +--------------------+----------------------------------------+----------------------------------------------------------------------------------+
+    | ``-alloc_flags``   | ``#BSUB -alloc_flags "gpumps smt1"``   | Used to request                                                                  |
+    |                    |                                        | GPU Multi-Process Service (MPS) and to set SMT (Simultaneous Multithreading)     |
+    |                    |                                        | levels. Only one "#BSUB alloc\_flags" command is recognized so multiple          |
+    |                    |                                        | alloc\_flags options need to be enclosed in quotes and space-separated. Setting  |
+    |                    |                                        | gpumps enables NVIDIA’s Multi-Process Service, which allows multiple MPI ranks   |
+    |                    |                                        | to simultaneously access a GPU. Setting smt\ *n* (where *n* is 1, 2, or 4) sets  |
+    |                    |                                        | different SMT levels. To run with 2 hardware threads per physical core, you’d    |
+    |                    |                                        | use smt2. The default level is smt4.                                             |
+    +--------------------+----------------------------------------+----------------------------------------------------------------------------------+
+
+Allocation-wide Options
+^^^^^^^^^^^^^^^^^^^^^^^
+
+The ``-alloc_flags`` option to ``bsub`` is used to set allocation-wide options.
+These settings are applied to every compute node in a job. Only one instance of
+the flag is accepted, and multiple ``alloc_flags`` values should be enclosed in
+quotes and space-separated. For example, ``-alloc_flags "gpumps smt1``.
+
+The most common values (``smt{1,2,4}``, ``gpumps``, ``gpudefault``) are detailed in
+the following sections. 
+
+This option can also be used to provide additional resources to GPFS service
+processes, described in the `GPFS System Service Isolation
+<#gpfs-system-service-isolation>`__ section.
+
+Hardware Threads
+""""""""""""""""
+
+Hardware threads are a feature of the POWER9 processor through which
+individual physical cores can support multiple execution streams,
+essentially looking like one or more virtual cores (similar to
+hyperthreading on some Intel\ |R| microprocessors). This feature is often
+called Simultaneous Multithreading or SMT. The POWER9 processor on
+Summit supports SMT levels of 1, 2, or 4, meaning (respectively) each
+physical core looks like 1, 2, or 4 virtual cores. The SMT level is
+controlled by the ``-alloc_flags`` option to ``bsub``. For example, to
+set the SMT level to 2, add the line ``#BSUB –alloc_flags smt2`` to your
+batch script or add the option ``-alloc_flags smt2`` to you ``bsub``
+command line.
+
+The default SMT level is 4.
+
+MPS
+"""
+
+The Multi-Process Service (MPS) enables multiple processes (e.g. MPI
+ranks) to concurrently share the resources on a single GPU. This is
+accomplished by starting an MPS server process, which funnels the work
+from multiple CUDA contexts (e.g. from multiple MPI ranks) into a single
+CUDA context. In some cases, this can increase performance due to better
+utilization of the resources. As mentioned in the `Common bsub Options <#common-bsub-options>`__
+section above, MPS can be enabled with the ``-alloc_flags "gpumps"`` option to
+``bsub``. The following screencast shows an example of how to start an MPS
+server process for a job: https://vimeo.com/292016149
+
+GPU Compute Modes
+"""""""""""""""""
+
+Summit's V100 GPUs are configured to have a default compute mode of
+``EXCLUSIVE_PROCESS``. In this mode, the GPU is assigned to only a single
+process at a time, and can accept work from multiple process threads
+concurrently.
+
+
+It may be desirable to change the GPU's compute mode to ``DEFAULT``, which
+enables multiple processes and their threads to share and submit work to it
+simultaneously. To change the compute mode to ``DEFAULT``, use the
+``-alloc_flags gpudefault`` option.
+
+NVIDIA recommends using the ``EXCLUSIVE_PROCESS`` compute mode (the default on
+Summit) when using the Multi-Process Service, but both MPS and the compute mode
+can be changed by providing both values: ``-alloc_flags "gpumps gpudefault"``. 
+
+Batch Environment Variables
+---------------------------
+
+LSF provides a number of environment variables in your job’s shell
+environment. Many job parameters are stored in environment variables and
+can be queried within the batch job. Several of these variables are
+summarized in the table below. This is not an all-inclusive list of
+variables available to your batch job; in particular only LSF variables
+are discussed, not the many “standard” environment variables that will
+be available (such as ``$PATH``).
+
++-----------------------+------------------------------------------------------+
+| Variable              | Description                                          |
++=======================+======================================================+
+| ``LSB_JOBID``         | The ID assigned to the job by LSF                    |
++-----------------------+------------------------------------------------------+
+| ``LS_JOBPID``         | The job’s process ID                                 |
++-----------------------+------------------------------------------------------+
+| ``LSB_JOBINDEX``      | The job’s index (if it belongs to a job array)       |
++-----------------------+------------------------------------------------------+
+| ``LSB_HOSTS``         | The hosts assigned to run the job                    |
++-----------------------+------------------------------------------------------+
+| ``LSB_QUEUE``         | The queue from which the job was dispatched          |
++-----------------------+------------------------------------------------------+
+| ``LSB_INTERACTIVE``   | Set to “Y” for an interactive job; otherwise unset   |
++-----------------------+------------------------------------------------------+
+| ``LS_SUBCWD``         | The directory from which the job was submitted       |
++-----------------------+------------------------------------------------------+
+
+Job States
+----------
+
+A job will progress through a number of states through its lifetime. The
+states you’re most likely to see are:
+
++---------+-----------------------------------------------------------------------------+
+| State   | Description                                                                 |
++=========+=============================================================================+
+| PEND    | Job is pending                                                              |
++---------+-----------------------------------------------------------------------------+
+| RUN     | Job is running                                                              |
++---------+-----------------------------------------------------------------------------+
+| DONE    | Job completed normally (with an exit code of 0)                             |
++---------+-----------------------------------------------------------------------------+
+| EXIT    | Job completed abnormally                                                    |
++---------+-----------------------------------------------------------------------------+
+| PSUSP   | Job was suspended (either by the user or an administrator) while pending    |
++---------+-----------------------------------------------------------------------------+
+| USUSP   | Job was suspended (either by the user or an administrator) after starting   |
++---------+-----------------------------------------------------------------------------+
+| SSUSP   | Job was suspended by the system after starting                              |
++---------+-----------------------------------------------------------------------------+
+
+.. note::
+    Jobs may end up in the PSUSP state for a number of reasons. Two common reasons for PSUSP jobs include jobs that have been held by the user or jobs with unresolved dependencies. 
+    
+    Another common reason that jobs end up in a PSUSP state is a job that the system is unable to start. You may notice a job alternating between PEND and RUN states a few times and ultimately ends up as PSUSP. In this case, the system attempted to start the job but failed for some reason. This can be due to a system issue, but we have also seen this casued by improper settings on user ``~/.ssh/config`` files. (The batch system uses SSH, and the improper settings cause SSH to fail.) If you notice your jobs alternating between PEND and RUN, you might want to check permissions of your ``~/.ssh/config`` file to make sure it does not have write permission for "group" or "other". (A setting of read/write for the user and no other permissions, which can be set with ``chmod 600 ~/.ssh/config``, is recommended.)
+
+Scheduling Policy
+-----------------
+
+In a simple batch queue system, jobs run in a first-in, first-out (FIFO)
+order. This often does not make effective use of the system. A large job
+may be next in line to run. If the system is using a strict FIFO queue,
+many processors sit idle while the large job waits to run. *Backfilling*
+would allow smaller, shorter jobs to use those otherwise idle resources,
+and with the proper algorithm, the start time of the large job would not
+be delayed. While this does make more effective use of the system, it
+indirectly encourages the submission of smaller jobs.
+
+The DOE Leadership-Class Job Mandate
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+As a DOE Leadership Computing Facility, the OLCF has a mandate that a
+large portion of Summit's usage come from large, *leadership-class* (aka
+*capability*) jobs. To ensure the OLCF complies with DOE directives, we
+strongly encourage users to run jobs on Summit that are as large as
+their code will warrant. To that end, the OLCF implements queue policies
+that enable large jobs to run in a timely fashion.
+
+.. note::
+    The OLCF implements queue policies that encourage the
+    submission and timely execution of large, leadership-class jobs on
+    Summit.
+
+The basic priority-setting mechanism for jobs waiting in the queue is
+the time a job has been waiting relative to other jobs in the queue.
+
+If your jobs require resources outside these queue policies such as higher priority or longer walltimes, please contact help@olcf.ornl.gov. 
+
+Job Priority by Processor Count
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Jobs are *aged* according to the job's requested processor count (older
+age equals higher queue priority). Each job's requested processor count
+places it into a specific *bin*. Each bin has a different aging
+parameter, which all jobs in the bin receive.
+
++-------+-------------+-------------+------------------------+----------------------+
+| Bin   | Min Nodes   | Max Nodes   | Max Walltime (Hours)   | Aging Boost (Days)   |
++=======+=============+=============+========================+======================+
+| 1     | 2,765       | 4,608       | 24.0                   | 15                   |
++-------+-------------+-------------+------------------------+----------------------+
+| 2     | 922         | 2,764       | 24.0                   | 10                   |
++-------+-------------+-------------+------------------------+----------------------+
+| 3     | 92          | 921         | 12.0                   | 0                    |
++-------+-------------+-------------+------------------------+----------------------+
+| 4     | 46          | 91          | 6.0                    | 0                    |
++-------+-------------+-------------+------------------------+----------------------+
+| 5     | 1           | 45          | 2.0                    | 0                    |
++-------+-------------+-------------+------------------------+----------------------+
+
+``batch`` Queue Policy
+"""""""""""""""""""""""
+
+The ``batch`` queue (and the ``batch-spi`` queue for Moderate Enhanced security
+enclave projects) is the default queue for production work on Summit.  Most
+work on Summit is handled through this queue. It enforces the following
+policies:
+
+-  Limit of (4) *eligible-to-run* jobs per user.
+-  Jobs in excess of the per user limit above will be placed into a
+   *held* state, but will change to eligible-to-run at the appropriate
+   time.
+-  Users may have only (100) jobs queued in the ``batch`` queue at any state at any time.
+   Additional jobs will be rejected at submit time.
+
+.. note::
+    The *eligible-to-run* state is not the *running* state.
+    Eligible-to-run jobs have not started and are waiting for resources.
+    Running jobs are actually executing.
+
+``batch-hm`` Queue Policy
+"""""""""""""""""""""""""
+
+The ``batch-hm`` queue (and the ``batch-hm-spi`` queue for Moderate Enhanced
+security enclave projects) is used to access Summit's high-memory nodes.  Jobs
+may use all 54 nodes. It enforces the following policies:
+
+-  Limit of (4) *eligible-to-run* jobs per user.
+-  Jobs in excess of the per user limit above will be placed into a
+   *held* state, but will change to eligible-to-run at the appropriate
+   time.
+-  Users may have only (25) jobs queued in the ``batch-hm`` queue at any state at any time.
+   Additional jobs will be rejected at submit time.
+
+**batch-hm job limits:**
+
++-------------+-------------+------------------------+
+| Min Nodes   | Max Nodes   | Max Walltime (Hours)   |
++=============+=============+========================+
+| 1           | 54          | 24.0                   |
++-------------+-------------+------------------------+
+
+To submit a job to the ``batch-hm`` queue, add the ``-q batch-hm`` option to your
+``bsub`` command or ``#BSUB -q batch-hm`` to your job script.
+
+
+``killable`` Queue Policy
+""""""""""""""""""""""""""
+
+The ``killable`` queue is a preemptable queue that allows jobs in bins 4 and 5
+to request walltimes up to 24 hours. Jobs submitted to the killable queue will
+be preemptable once the job reaches the guaranteed runtime limit as shown in the
+table below. For example, a job in bin 5 submitted to the killable queue can
+request a walltime of 24 hours. The job will be preemptable after two hours of
+run time. Similarly, a job in bin 4 will be preemptable after six hours of run
+time. Once a job is preempted, the job will be resubmitted by default with the
+original limits as requested in the job script and will have the same ``JOBID``.
+
+**Preemptable job limits:**
+
++-------+-------------+-------------+------------------------+----------------------+
+| Bin   | Min Nodes   | Max Nodes   | Max Walltime (Hours)   | Guaranteed Walltime  |
++=======+=============+=============+========================+======================+
+| 4     | 46          | 91          | 24.0                   |  6.0 (hours)         |
++-------+-------------+-------------+------------------------+----------------------+
+| 5     | 1           | 45          | 24.0                   |  2.0 (hours)         |
++-------+-------------+-------------+------------------------+----------------------+
+
+.. warning:: If a job in the ``killable`` queue does not reach its requested
+    walltime, it will continue to use allocation time with each automatic
+    resubmission until it either reaches the requested walltime during a single
+    continuous run, or is manually killed by the user. Allocations are always
+    charged based on actual compute time used by all jobs.
+
+To submit a job to the ``killable`` queue, add the ``-q killable`` option to your
+``bsub`` command or ``#BSUB -q killable`` to your job script.
+
+To prevent a preempted job from being automatically requeued, the ``BSUB -rn``
+flag can be used at submit time.
+
+
+``debug`` Queue Policy
+""""""""""""""""""""""""""
+
+The ``debug`` queue (and the ``debug-spi`` queue for Moderate Enhanced security
+enclave projects) can be used to access Summit's compute resources for short
+non-production debug tasks.  The queue provides a higher priority compared to
+jobs of the same job size bin in production queues.  Production work and job
+chaining in the debug queue is prohibited.  Each user is limited to one job in
+any state in the debug queue at any one point. Attempts to submit multiple jobs
+to the debug queue will be rejected upon job submission.
+
+**debug job limits:**
+
++-------------+--------------+------------------------+---------------------------------+--------------------+
+| Min Nodes   | Max Nodes    | Max Walltime (Hours)   | Max queued any state (per user) | Aging Boost (Days) |
++=============+==============+========================+=================================+====================+
+| 1           | unlimited    | 2.0                    | 1                               | 2                  |
++-------------+--------------+------------------------+---------------------------------+--------------------+
+
+To submit a job to the ``debug`` queue, add the ``-q debug`` option to your
+``bsub`` command or ``#BSUB -q debug`` to your job script.
+
+
+.. note::
+    Production work and job chaining in the ``debug`` queue is prohibited.
+
+SPI/KDI Citadel Queue Policy (Moderate Enhanced Projects)
+"""""""""""""""""""""""""""""""""""""""""""""""""""""""""
+
+There are special queue names when submitting jobs to ``citadel.ccs.ornl.gov``
+(the Moderate Enhanced version of Summit). These queues are: ``batch-spi``,
+``batch-hm-spi``, and ``debug-spi``.  For example, to submit a job to the
+``batch-spi`` queue on Citadel, you would need ``-q batch-spi`` when using the
+``bsub`` command or ``#BSUB -q batch-spi`` when using a job script.
+
+Except for the enhanced security policies for jobs in these queues, all other
+queue properties are the same as the respective Summit queues described above,
+such as maximum walltime and number of eligible running jobs.
+
+.. warning::
+    If you submit a job to a "normal" Summit queue while on Citadel, such as
+    ``-q batch``, your job will be unable to launch.
+
+Allocation Overuse Policy
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Projects that overrun their allocation are still allowed to run on OLCF
+systems, although at a reduced priority. Like the adjustment for the
+number of processors requested above, this is an adjustment to the
+apparent submit time of the job. However, this adjustment has the effect
+of making jobs appear much younger than jobs submitted under projects
+that have not exceeded their allocation. In addition to the priority
+change, these jobs are also limited in the amount of wall time that can
+be used. For example, consider that ``job1`` is submitted at the same
+time as ``job2``. The project associated with ``job1`` is over its
+allocation, while the project for ``job2`` is not. The batch system will
+consider ``job2`` to have been waiting for a longer time than ``job1``.
+Additionally, projects that are at 125% of their allocated time will be
+limited to only 3 running jobs at a time. The adjustment to the
+apparent submit time depends upon the percentage that the project is
+over its allocation, as shown in the table below:
+
++------------------------+----------------------+
+| % Of Allocation Used   | Priority Reduction   |
++========================+======================+
+| < 100%                 | 0 days               |
++------------------------+----------------------+
+| 100% to 125%           | 30 days              |
++------------------------+----------------------+
+| > 125%                 | 365 days             |
++------------------------+----------------------+
+
+System Reservation Policy
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Projects may request to reserve a set of nodes for a period of time
+by contacting help@olcf.ornl.gov. If the reservation is granted, the reserved nodes will be
+blocked from general use for a given period of time. Only users that
+have been authorized to use the reservation can utilize those resources.
+To access the reservation, please add -U {reservation name} to bsub or job script.
+Since no other users can access the reserved resources, it is crucial
+that groups given reservations take care to ensure the utilization on
+those resources remains high. To prevent reserved resources from
+remaining idle for an extended period of time, reservations are
+monitored for inactivity. If activity falls below 50% of the reserved
+resources for more than (30) minutes, the reservation will be canceled
+and the system will be returned to normal scheduling. A new reservation
+must be requested if this occurs.
+
+The requesting project's allocation is charged according to the time window
+granted, regardless of actual utilization. For example, an 8-hour, 2,000
+node reservation on Summit would be equivalent to using 16,000 Summit
+node-hours of a project's allocation.
+
+--------------
+
+Job Dependencies
+----------------
+
+As is the case with many other queuing systems, it is possible to place
+dependencies on jobs to prevent them from running until other jobs have
+started/completed/etc. Several possible dependency settings are
+described in the table below:
+
+.. table::
+    :widths: 27 73
+
+    +-----------------------------------------------+---------------------------------------------------------------------------------+
+    | Expression                                    | Meaning                                                                         |
+    +===============================================+=================================================================================+
+    | ``#BSUB -w started(12345)``                   | The job will not start until                                                    |
+    |                                               | job 12345 starts. Job 12345 is considered to have started if is in any of the   |
+    |                                               | following states: USUSP, SSUSP, DONE, EXIT or RUN (with any pre-execution       |
+    |                                               | command specified by ``bsub -E`` completed)                                     |
+    +-----------------------------------------------+---------------------------------------------------------------------------------+
+    | ``#BSUB -w done(12345)`` ``#BSUB -w 12345``   | The job will not start until                                                    |
+    |                                               | job 12345 has a state of DONE (i.e. completed normally). If a job ID is given   |
+    |                                               | with no condition, ``done()`` is assumed.                                       |
+    +-----------------------------------------------+---------------------------------------------------------------------------------+
+    | ``#BSUB -w exit(12345)``                      | The job will not start until                                                    |
+    |                                               | job 12345 has a state of EXIT (i.e. completed abnormally)                       |
+    +-----------------------------------------------+---------------------------------------------------------------------------------+
+    | ``#BSUB -w ended(12345)``                     | The job will not start until                                                    |
+    |                                               | job 12345 has a state of EXIT or DONE                                           |
+    +-----------------------------------------------+---------------------------------------------------------------------------------+
+
+Dependency expressions can be combined with logical operators. For
+example, if you want a job held until job 12345 is DONE and job 12346
+has started, you can use ``#BSUB -w "done(12345) && started(12346)"``
+
+
+
+.. _job-launcher-jsrun:
+
+Job Launcher (jsrun)
+--------------------
+
+The default job launcher for Summit is ``jsrun``. jsrun was developed by
+IBM for the Oak Ridge and Livermore Power systems. The tool will execute
+a given program on resources allocated through the LSF batch scheduler;
+similar to ``mpirun`` and ``aprun`` functionality.
+
+Compute Node Description
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following compute node image will be used to discuss jsrun resource
+sets and layout.
+
+
+.. image:: /images/summit-node-description-1.png
+   :width: 85%
+   :align: center
+
+-  1 node
+-  2 sockets (grey)
+-  42 physical cores\* (dark blue)
+-  168 hardware cores (light blue)
+-  6 GPUs (orange)
+-  2 Memory blocks (yellow)
+
+**\*Core Isolation:** 1 core on each socket has been set aside for
+overhead and is not available for allocation through jsrun. The core has
+been omitted and is not shown in the above image.
+
+Resource Sets
+^^^^^^^^^^^^^
+
+While jsrun performs similar job launching functions as aprun and
+mpirun, its syntax is very different. A large reason for syntax
+differences is the introduction of the ``resource set`` concept. Through
+resource sets, jsrun can control how a node appears to each job. Users
+can, through jsrun command line flags, control which resources on a node
+are visible to a job. Resource sets also allow the ability to run
+multiple jsruns simultaneously within a node. Under the covers, a
+resource set is a cgroup.
+
+At a high level, a resource set allows users to configure what a node
+look like to their job.
+
+jsrun will create one or more resource sets within a node. Each resource
+set will contain 1 or more cores and 0 or more GPUs. A resource set can
+span sockets, but it may not span a node. While a resource set can span
+sockets within a node, consideration should be given to the cost of
+cross-socket communication. By creating resource sets only within
+sockets, costly communication between sockets can be prevented.
+
+Subdividing a Node with Resource Sets
+"""""""""""""""""""""""""""""""""""""
+
+Resource sets provides the ability to subdivide node’s resources into
+smaller groups. The following examples show how a node can be subdivided
+and how many resource set could fit on a node.
+
+.. image:: /images/summit-resource-set-subdivide.png
+   :align: center
+
+Multiple Methods to Creating Resource Sets
+""""""""""""""""""""""""""""""""""""""""""
+
+Resource sets should be created to fit code requirements. The following
+examples show multiple ways to create resource sets that allow two MPI
+tasks access to a single GPU.
+
+#. 6 resource sets per node: 1 GPU, 2 cores per (Titan)
+
+   .. image:: https://www.olcf.ornl.gov/wp-content/uploads/2018/03/RS-summit-example-1GPU-2Cores.png
+      :align: center
+
+   In this case, CPUs can only see single assigned GPU.
+
+#. 2 resource sets per node: 3 GPUs and 6 cores per socket
+
+   .. image:: https://www.olcf.ornl.gov/wp-content/uploads/2018/03/RS-summit-example-3GPU-6Cores.png
+      :align: center
+
+   In this case, all 6 CPUs can see 3 GPUs. Code must manage CPU -> GPU
+   communication. CPUs on socket0 can not access GPUs or Memory on socket1.
+
+#. Single resource set per node: 6 GPUs, 12 cores
+
+   .. image:: https://www.olcf.ornl.gov/wp-content/uploads/2018/03/RS-summit-example-6GPU-12Core.png
+      :align: center
+
+   In this case, all 12 CPUs can see all node’s 6 GPUs. Code must manage CPU to
+   GPU communication. CPUs on socket0 can access GPUs and Memory on socket1.
+   Code must manage cross socket communication.
+
+Designing a Resource Set
+""""""""""""""""""""""""
+
+Resource sets allow each jsrun to control how the node appears to a
+code. This method is unique to jsrun, and requires thinking of each job
+launch differently than aprun or mpirun. While the method is unique, the
+method is not complicated and can be reasoned in a few basic steps.
+
+The first step to creating resource sets is understanding how a code would
+like the node to appear. For example, the number of tasks/threads per
+GPU. Once this is understood, the next step is to simply calculate the
+number of resource sets that can fit on a node. From here, the number of
+needed nodes can be calculated and passed to the batch job request.
+
+The basic steps to creating resource sets:
+
+1) Understand how your code expects to interact with the system.
+    How many tasks/threads per GPU?
+
+    Does each task expect to see a single GPU? Do multiple tasks expect
+    to share a GPU? Is the code written to internally manage task to GPU
+    workload based on the number of available cores and GPUs?
+2) Create resource sets containing the needed GPU to task binding
+    Based on how your code expects to interact with the system, you can
+    create resource sets containing the needed GPU and core resources.
+    If a code expects to utilize one GPU per task, a resource set would
+    contain one core and one GPU. If a code expects to pass work to a
+    single GPU from two tasks, a resource set would contain two cores
+    and one GPU.
+3) Decide on the number of resource sets needed
+    Once you understand tasks, threads, and GPUs in a resource set, you
+    simply need to decide the number of resource sets needed.
+
+As on any system, it is useful to keep in mind the hardware underneath every
+execution. This is particularly true when laying out resource sets.
+
+Launching a Job with jsrun
+--------------------------
+
+jsrun Format
+^^^^^^^^^^^^
+
+::
+
+      jsrun    [ -n #resource sets ]   [tasks, threads, and GPUs within each resource set]   program [ program args ]
+
+Common jsrun Options
+^^^^^^^^^^^^^^^^^^^^
+
+Below are common jsrun options. More flags and details can be found in the jsrun
+man page. The defaults listed in the table below are the OLCF defaults and take
+precedence over those mentioned in the man page.
+
+.. table::
+    :widths: 20 5 35 40
+
+    +---------------------------+--------+------------------------------------------------------+------------------------------+
+    | Flags                              |                                                      |                              |
+    +---------------------------+--------+  Description                                         + Default Value                +
+    | Long                      | Short  |                                                      |                              |
+    +===========================+========+======================================================+==============================+
+    | ``--nrs``                 | ``-n`` | Number of resource sets                              | All available physical cores |
+    +---------------------------+--------+------------------------------------------------------+------------------------------+
+    | ``--tasks_per_rs``        | ``-a`` | Number of MPI tasks (ranks) per resource set         | Not set by default, instead  |
+    |                           |        |                                                      | total tasks (-p) set         |
+    +---------------------------+--------+------------------------------------------------------+------------------------------+
+    | ``--cpu_per_rs``          | ``-c`` | Number of CPUs (cores) per resource set.             | 1                            |
+    +---------------------------+--------+------------------------------------------------------+------------------------------+
+    | ``--gpu_per_rs``          | ``-g`` | Number of GPUs per resource set                      | 0                            |
+    +---------------------------+--------+------------------------------------------------------+------------------------------+
+    | ``--bind``                | ``-b`` | Binding of tasks within a resource set. Can be none, | packed:1                     |
+    |                           |        | rs, or packed:#                                      |                              |
+    +---------------------------+--------+------------------------------------------------------+------------------------------+
+    | ``--rs_per_host``         | ``-r`` | Number of resource sets per host                     | No default                   |
+    +---------------------------+--------+------------------------------------------------------+------------------------------+
+    | ``--latency_priority``    | ``-l`` | Latency Priority. Controls layout                    | gpu-cpu,cpu-mem,cpu-cpu      |
+    |                           |        | priorities. Can currently be cpu-cpu or gpu-cpu      |                              |
+    +---------------------------+--------+------------------------------------------------------+------------------------------+
+    | ``--launch_distribution`` | ``-d`` | How tasks are started on resource sets               | packed                       |
+    +---------------------------+--------+------------------------------------------------------+------------------------------+
+
+It's recommended to explicitly specify ``jsrun`` options and not rely on the
+default values. This most often includes ``--nrs``,\ ``--cpu_per_rs``,
+``--gpu_per_rs``, ``--tasks_per_rs``, ``--bind``, and ``--launch_distribution``.
+
+Jsrun Examples
+--------------
+
+The below examples were launched in the following 2 node interactive
+batch job:
+
+::
+
+    summit> bsub -nnodes 2 -Pprj123 -W02:00 -Is $SHELL
+
+Single MPI Task, single GPU per RS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following example will create 12 resource sets each with 1 MPI task
+and 1 GPU. Each MPI task will have access to a single GPU.
+
+Rank 0 will have access to GPU 0 on the first node ( red resource set).
+Rank 1 will have access to GPU 1 on the first node ( green resource set).
+This pattern will continue until 12 resources sets have been created.
+
+The following jsrun command will request 12 resource sets (``-n12``) 6
+per node (``-r6``). Each resource set will contain 1 MPI task (``-a1``),
+1 GPU (``-g1``), and 1 core (``-c1``).
+
+.. image:: /images/summit-jsrun-example-1Core-1GPU.png
+   :align: center
+
+::
+
+    summit> jsrun -n12 -r6 -a1 -g1 -c1 ./a.out
+    Rank:    0; NumRanks: 12; RankCore:   0; Hostname: h41n04; GPU: 0
+    Rank:    1; NumRanks: 12; RankCore:   4; Hostname: h41n04; GPU: 1
+    Rank:    2; NumRanks: 12; RankCore:   8; Hostname: h41n04; GPU: 2
+    Rank:    3; NumRanks: 12; RankCore:  88; Hostname: h41n04; GPU: 3
+    Rank:    4; NumRanks: 12; RankCore:  92; Hostname: h41n04; GPU: 4
+    Rank:    5; NumRanks: 12; RankCore:  96; Hostname: h41n04; GPU: 5
+
+    Rank:    6; NumRanks: 12; RankCore:   0; Hostname: h41n03; GPU: 0
+    Rank:    7; NumRanks: 12; RankCore:   4; Hostname: h41n03; GPU: 1
+    Rank:    8; NumRanks: 12; RankCore:   8; Hostname: h41n03; GPU: 2
+    Rank:    9; NumRanks: 12; RankCore:  88; Hostname: h41n03; GPU: 3
+    Rank:   10; NumRanks: 12; RankCore:  92; Hostname: h41n03; GPU: 4
+    Rank:   11; NumRanks: 12; RankCore:  96; Hostname: h41n03; GPU: 5
+
+Multiple tasks, single GPU per RS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following jsrun command will request 12 resource sets (``-n12``).
+Each resource set will contain 2 MPI tasks (``-a2``), 1 GPU
+(``-g1``), and 2 cores (``-c2``). 2 MPI tasks will have access to a
+single GPU. Ranks 0 - 1 will have access to GPU 0 on the first node (
+red resource set). Ranks 2 - 3 will have access to GPU 1 on the first
+node ( green resource set). This pattern will continue until 12 resource
+sets have been created.
+
+.. image:: /images/summit-jsrun-example-2taskperGPU.png
+   :align: center
+
+
+**Adding cores to the RS:** The ``-c`` flag should be used to request
+the needed cores for tasks and treads. The default -c core count is 1.
+In the above example, if -c is not specified both tasks will run on a
+single core.
+
+::
+
+    summit> jsrun -n12 -a2 -g1 -c2 -dpacked ./a.out | sort
+    Rank:    0; NumRanks: 24; RankCore:   0; Hostname: a01n05; GPU: 0
+    Rank:    1; NumRanks: 24; RankCore:   4; Hostname: a01n05; GPU: 0
+
+    Rank:    2; NumRanks: 24; RankCore:   8; Hostname: a01n05; GPU: 1
+    Rank:    3; NumRanks: 24; RankCore:  12; Hostname: a01n05; GPU: 1
+
+    Rank:    4; NumRanks: 24; RankCore:  16; Hostname: a01n05; GPU: 2
+    Rank:    5; NumRanks: 24; RankCore:  20; Hostname: a01n05; GPU: 2
+
+    Rank:    6; NumRanks: 24; RankCore:  88; Hostname: a01n05; GPU: 3
+    Rank:    7; NumRanks: 24; RankCore:  92; Hostname: a01n05; GPU: 3
+
+    Rank:    8; NumRanks: 24; RankCore:  96; Hostname: a01n05; GPU: 4
+    Rank:    9; NumRanks: 24; RankCore: 100; Hostname: a01n05; GPU: 4
+
+    Rank:   10; NumRanks: 24; RankCore: 104; Hostname: a01n05; GPU: 5
+    Rank:   11; NumRanks: 24; RankCore: 108; Hostname: a01n05; GPU: 5
+
+    Rank:   12; NumRanks: 24; RankCore:   0; Hostname: a01n01; GPU: 0
+    Rank:   13; NumRanks: 24; RankCore:   4; Hostname: a01n01; GPU: 0
+
+    Rank:   14; NumRanks: 24; RankCore:   8; Hostname: a01n01; GPU: 1
+    Rank:   15; NumRanks: 24; RankCore:  12; Hostname: a01n01; GPU: 1
+
+    Rank:   16; NumRanks: 24; RankCore:  16; Hostname: a01n01; GPU: 2
+    Rank:   17; NumRanks: 24; RankCore:  20; Hostname: a01n01; GPU: 2
+
+    Rank:   18; NumRanks: 24; RankCore:  88; Hostname: a01n01; GPU: 3
+    Rank:   19; NumRanks: 24; RankCore:  92; Hostname: a01n01; GPU: 3
+
+    Rank:   20; NumRanks: 24; RankCore:  96; Hostname: a01n01; GPU: 4
+    Rank:   21; NumRanks: 24; RankCore: 100; Hostname: a01n01; GPU: 4
+
+    Rank:   22; NumRanks: 24; RankCore: 104; Hostname: a01n01; GPU: 5
+    Rank:   23; NumRanks: 24; RankCore: 108; Hostname: a01n01; GPU: 5
+
+    summit>
+
+Multiple Task, Multiple GPU per RS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following example will create 4 resource sets each with 6 tasks and
+3 GPUs. Each set of 6 MPI tasks will have access to 3 GPUs. Ranks 0 - 5
+will have access to GPUs 0 - 2 on the first socket of the first node (
+red resource set). Ranks 6 - 11 will have access to GPUs 3 - 5 on the
+second socket of the first node ( green resource set). This pattern will
+continue until 4 resource sets have been created. The following jsrun
+command will request 4 resource sets (``-n4``). Each resource set will
+contain 6 MPI tasks (``-a6``), 3 GPUs (``-g3``), and 6 cores
+(``-c6``).
+
+.. image:: /images/RS-summit-example-24Tasks-3GPU-6Cores.png
+   :align: center
+
+::
+
+    summit> jsrun -n 4 -a 6 -c 6 -g 3 -d packed -l GPU-CPU ./a.out
+    Rank:    0; NumRanks: 24; RankCore:   0; Hostname: a33n06; GPU: 0, 1, 2
+    Rank:    1; NumRanks: 24; RankCore:   4; Hostname: a33n06; GPU: 0, 1, 2
+    Rank:    2; NumRanks: 24; RankCore:   8; Hostname: a33n06; GPU: 0, 1, 2
+    Rank:    3; NumRanks: 24; RankCore:  12; Hostname: a33n06; GPU: 0, 1, 2
+    Rank:    4; NumRanks: 24; RankCore:  16; Hostname: a33n06; GPU: 0, 1, 2
+    Rank:    5; NumRanks: 24; RankCore:  20; Hostname: a33n06; GPU: 0, 1, 2
+
+    Rank:    6; NumRanks: 24; RankCore:  88; Hostname: a33n06; GPU: 3, 4, 5
+    Rank:    7; NumRanks: 24; RankCore:  92; Hostname: a33n06; GPU: 3, 4, 5
+    Rank:    8; NumRanks: 24; RankCore:  96; Hostname: a33n06; GPU: 3, 4, 5
+    Rank:    9; NumRanks: 24; RankCore: 100; Hostname: a33n06; GPU: 3, 4, 5
+    Rank:   10; NumRanks: 24; RankCore: 104; Hostname: a33n06; GPU: 3, 4, 5
+    Rank:   11; NumRanks: 24; RankCore: 108; Hostname: a33n06; GPU: 3, 4, 5
+
+    Rank:   12; NumRanks: 24; RankCore:   0; Hostname: a33n05; GPU: 0, 1, 2
+    Rank:   13; NumRanks: 24; RankCore:   4; Hostname: a33n05; GPU: 0, 1, 2
+    Rank:   14; NumRanks: 24; RankCore:   8; Hostname: a33n05; GPU: 0, 1, 2
+    Rank:   15; NumRanks: 24; RankCore:  12; Hostname: a33n05; GPU: 0, 1, 2
+    Rank:   16; NumRanks: 24; RankCore:  16; Hostname: a33n05; GPU: 0, 1, 2
+    Rank:   17; NumRanks: 24; RankCore:  20; Hostname: a33n05; GPU: 0, 1, 2
+
+    Rank:   18; NumRanks: 24; RankCore:  88; Hostname: a33n05; GPU: 3, 4, 5
+    Rank:   19; NumRanks: 24; RankCore:  92; Hostname: a33n05; GPU: 3, 4, 5
+    Rank:   20; NumRanks: 24; RankCore:  96; Hostname: a33n05; GPU: 3, 4, 5
+    Rank:   21; NumRanks: 24; RankCore: 100; Hostname: a33n05; GPU: 3, 4, 5
+    Rank:   22; NumRanks: 24; RankCore: 104; Hostname: a33n05; GPU: 3, 4, 5
+    Rank:   23; NumRanks: 24; RankCore: 108; Hostname: a33n05; GPU: 3, 4, 5
+    summit>
+
+
+Common Use Cases
+^^^^^^^^^^^^^^^^
+
+The following table provides a quick reference for creating resource
+sets of various common use cases. The ``-n`` flag can be altered to
+specify the number of resource sets needed.
+
++-----------------+-------------+-----------+------------------+--------+---------------------------------------+
+| Resource Sets   | MPI Tasks   | Threads   | Physical Cores   | GPUs   | jsrun Command                         |
++=================+=============+===========+==================+========+=======================================+
+| 1               | 42          | 0         | 42               | 0      | jsrun -n1 -a42 -c42 -g0               |
++-----------------+-------------+-----------+------------------+--------+---------------------------------------+
+| 1               | 1           | 0         | 1                | 1      | jsrun -n1 -a1 -c1 -g1                 |
++-----------------+-------------+-----------+------------------+--------+---------------------------------------+
+| 1               | 2           | 0         | 2                | 1      | jsrun -n1 -a2 -c2 -g1                 |
++-----------------+-------------+-----------+------------------+--------+---------------------------------------+
+| 1               | 1           | 0         | 1                | 2      | jsrun -n1 -a1 -c1 -g2                 |
++-----------------+-------------+-----------+------------------+--------+---------------------------------------+
+| 1               | 1           | 21        | 21               | 3      | jsrun -n1 -a1 -c21 -g3 -bpacked:21    |
++-----------------+-------------+-----------+------------------+--------+---------------------------------------+
+
+jsrun Tools
+^^^^^^^^^^^
+
+This section describes tools that users might find helpful to better
+understand the jsrun job launcher.
+
+hello\_jsrun
+""""""""""""
+
+hello\_jsrun is a "Hello World"-type program that users can run on
+Summit nodes to better understand how MPI ranks and OpenMP threads are
+mapped to the hardware. https://code.ornl.gov/t4p/Hello_jsrun A
+screencast showing how to use Hello\_jsrun is also available:
+https://vimeo.com/261038849
+
+Job Step Viewer
+"""""""""""""""
+
+`Job Step Viewer <https://jobstepviewer.olcf.ornl.gov/>`__ provides a graphical view of an application's runtime layout on Summit.
+It allows users to preview and quickly iterate with multiple ``jsrun`` options to 
+understand and optimize job launch.
+
+For bug reports or suggestions, please email help@olcf.ornl.gov.
+
+Usage
+_____
+
+1. Request a Summit allocation
+    * ``bsub -W 10 -nnodes 2 -P $OLCF_PROJECT_ID -Is $SHELL``
+2. Load the ``job-step-viewer`` module
+    * ``module load job-step-viewer``
+3. Test out a ``jsrun`` line by itself, or provide an executable as normal
+    * ``jsrun -n12 -r6 -c7 -g1 -a1 -EOMP_NUM_THREADS=7 -brs``
+4. Visit the provided URL
+    * https://jobstepviewer.olcf.ornl.gov/summit/871957-1
+
+.. note::
+    Most Terminal applications have built-in shortcuts to directly open
+    web addresses in the default browser.
+
+    * MacOS Terminal.app: hold Command (⌘) and double-click on the URL
+    * iTerm2: hold Command (⌘) and single-click on the URL
+
+Limitations
+___________
+
+* (currently) Compiled with GCC toolchain only
+* Does not support MPMD-mode via ERF
+* OpenMP only supported with use of the ``OMP_NUM_THREADS`` environment variable.
+
+
+More Information
+^^^^^^^^^^^^^^^^
+
+This section provides some of the most commonly used LSF commands as
+well as some of the most useful options to those commands and
+information on ``jsrun``, Summit's job launch command. Many commands
+have much more information than can be easily presented here. More
+information about these commands is available via the online manual
+(i.e. ``man jsrun``). Additional LSF information can be found on `IBM’s
+website <https://www.ibm.com/support/knowledgecenter/en/SSWRJV/product_welcome_spectrum_lsf.html>`__.
+
+
+Using Multithreading in a Job
+-----------------------------
+
+
+Hardware Threads: Multiple Threads per Core
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Each physical core on Summit contains 4 hardware threads. The SMT level
+can be set using LSF flags (the default is smt4):
+
+SMT1
+
+::
+
+    #BSUB -alloc_flags smt1
+    jsrun -n1 -c1 -a1 -bpacked:1 csh -c 'echo $OMP_PLACES’
+    0
+
+SMT2
+
+::
+
+    #BSUB -alloc_flags smt2
+    jsrun -n1 -c1 -a1 -bpacked:1 csh -c 'echo $OMP_PLACES’
+    {0:2}
+
+SMT4
+
+::
+
+    #BSUB -alloc_flags smt4
+    jsrun -n1 -c1 -a1 -bpacked:1 csh -c 'echo $OMP_PLACES’
+    {0:4}
+
+
+
+Controlling Number of Threads for Tasks
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In addition to specifying the SMT level, you can also control the
+number of threads per MPI task by exporting the ``OMP_NUM_THREADS``
+environment variable. If you don't export it yourself, Jsrun will
+automatically set the number of threads based on the number of cores
+requested (``-c``) and the binding (``-b``) option. It is better to be
+explicit and set the ``OMP_NUM_THREADS`` value yourself rather than
+relying on Jsrun constructing it for you. Especially when you are
+using `Job Step Viewer`_ which relies on the presence of that
+environment variable to give you visual thread assignment information.
+
+In the below example, you could also do ``export OMP_NUM_THREADS=16`` in your
+job script instead of passing it as a ``-E`` flag to jsrun. The below example
+starts 1 resource set with 2 tasks and 8 cores, 4 cores bound to each task,
+16 threads for each task. We can set 16 threads since there are 4 cores
+per task and the default is smt4 for each core (4 * 4 = 16 threads).
+
+::
+   
+   jsrun -n1 -a2 -c8 -g1 -bpacked:4 -dpacked -EOMP_NUM_THREADS=16 csh -c 'echo $OMP_NUM_THREADS $OMP_PLACES'
+
+   16 0:4,4:4,8:4,12:4
+   16 16:4,20:4,24:4,28:4
+
+
+Be careful with assigning threads to tasks, as you might end up
+oversubscribing your cores. For example
+
+::
+   
+   jsrun -n1 -a2 -c8 -g1 -bpacked:4 -dpacked -EOMP_NUM_THREADS=32 csh -c 'echo $OMP_NUM_THREADS $OMP_PLACES'
+
+   Warning: OMP_NUM_THREADS=32 is greater than available PU's
+   Warning: OMP_NUM_THREADS=32 is greater than available PU's
+   Warning: OMP_NUM_THREADS=32 is greater than available PU's
+   Warning: OMP_NUM_THREADS=32 is greater than available PU's
+   32 16:4,20:4,24:4,28:4
+   32 0:4,4:4,8:4,12:4
+
+You can use `hello\_jsrun`_ or `Job Step Viewer`_ to see how the cores
+are being oversubscribed.
+
+Because of how jsrun sets up ``OMP_NUM_THREADS`` based on ``-c`` and
+``-b`` options if you don't specify the environment variable yourself,
+you can accidentally end up oversubscribing your cores. For example
+
+::
+   
+   jsrun -n1 -a2 -c8 -g1 -brs -dpacked  csh -c 'echo $OMP_NUM_THREADS $OMP_PLACES'
+
+   Warning: more than 1 task/rank assigned to a core
+   Warning: more than 1 task/rank assigned to a core
+   32 0:4,4:4,8:4,12:4,16:4,20:4,24:4,28:4
+   32 0:4,4:4,8:4,12:4,16:4,20:4,24:4,28:4
+
+Because jsrun sees 8 cores and the ``-brs`` flag, it assigns all 8 cores to
+each of the 2 tasks in the resource set. Jsrun will set up ``OMP_NUM_THREADS``
+as 32 (8 cores with 4 threads per core) which will apply to all the
+tasks in the resource set. This means that each task sees that it can
+have 32 threads (which means 64 threads for the 2 tasks combined) which
+will oversubscribe the cores and may decrease efficiency as a result.
+
+
+
+Example: Single Task, Single GPU, Multiple Threads per RS
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The following example will create 12 resource sets each with 1 task, 4
+threads, and 1 GPU. Each MPI task will start 4 threads and have access
+to 1 GPU. Rank 0 will have access to GPU 0 and start 4 threads on the
+first socket of the first node ( red resource set). Rank 2 will have
+access to GPU 1 and start 4 threads on the second socket of the first
+node ( green resource set). This pattern will continue until 12 resource
+sets have been created. The following jsrun command will create 12
+resource sets (``-n12``). Each resource set will contain 1 MPI task
+(``-a1``), 1 GPU (``-g1``), and 4 cores (``-c4``). Notice that
+more cores are requested than MPI tasks; the extra cores will be needed
+to place threads. Without requesting additional cores, threads will be
+placed on a single core.
+
+
+**Requesting Cores for Threads:** The ``-c`` flag should be used to
+request additional cores for thread placement. Without requesting
+additional cores, threads will be placed on a single core.
+
+**Binding Cores to Tasks:** The ``-b`` binding flag should be used to
+bind cores to tasks. Without specifying binding, all threads will be
+bound to the first core.
+
+::
+
+    summit> setenv OMP_NUM_THREADS 4
+    summit> jsrun -n12 -a1 -c4 -g1 -b packed:4 -d packed ./a.out
+    Rank: 0; RankCore: 0; Thread: 0; ThreadCore: 0; Hostname: a33n06; OMP_NUM_PLACES: {0},{4},{8},{12}
+    Rank: 0; RankCore: 0; Thread: 1; ThreadCore: 4; Hostname: a33n06; OMP_NUM_PLACES: {0},{4},{8},{12}
+    Rank: 0; RankCore: 0; Thread: 2; ThreadCore: 8; Hostname: a33n06; OMP_NUM_PLACES: {0},{4},{8},{12}
+    Rank: 0; RankCore: 0; Thread: 3; ThreadCore: 12; Hostname: a33n06; OMP_NUM_PLACES: {0},{4},{8},{12}
+
+    Rank: 1; RankCore: 16; Thread: 0; ThreadCore: 16; Hostname: a33n06; OMP_NUM_PLACES: {16},{20},{24},{28}
+    Rank: 1; RankCore: 16; Thread: 1; ThreadCore: 20; Hostname: a33n06; OMP_NUM_PLACES: {16},{20},{24},{28}
+    Rank: 1; RankCore: 16; Thread: 2; ThreadCore: 24; Hostname: a33n06; OMP_NUM_PLACES: {16},{20},{24},{28}
+    Rank: 1; RankCore: 16; Thread: 3; ThreadCore: 28; Hostname: a33n06; OMP_NUM_PLACES: {16},{20},{24},{28}
+
+    ...
+
+    Rank: 10; RankCore: 104; Thread: 0; ThreadCore: 104; Hostname: a33n05; OMP_NUM_PLACES: {104},{108},{112},{116}
+    Rank: 10; RankCore: 104; Thread: 1; ThreadCore: 108; Hostname: a33n05; OMP_NUM_PLACES: {104},{108},{112},{116}
+    Rank: 10; RankCore: 104; Thread: 2; ThreadCore: 112; Hostname: a33n05; OMP_NUM_PLACES: {104},{108},{112},{116}
+    Rank: 10; RankCore: 104; Thread: 3; ThreadCore: 116; Hostname: a33n05; OMP_NUM_PLACES: {104},{108},{112},{116}
+
+    Rank: 11; RankCore: 120; Thread: 0; ThreadCore: 120; Hostname: a33n05; OMP_NUM_PLACES: {120},{124},{128},{132}
+    Rank: 11; RankCore: 120; Thread: 1; ThreadCore: 124; Hostname: a33n05; OMP_NUM_PLACES: {120},{124},{128},{132}
+    Rank: 11; RankCore: 120; Thread: 2; ThreadCore: 128; Hostname: a33n05; OMP_NUM_PLACES: {120},{124},{128},{132}
+    Rank: 11; RankCore: 120; Thread: 3; ThreadCore: 132; Hostname: a33n05; OMP_NUM_PLACES: {120},{124},{128},{132}
+
+    summit>
+
+
+.. image:: /images/RS-summit-example-4Threads-4Core-1GPU.png
+   :align: center
+
+Launching Multiple Jsruns
+-------------------------
+
+Jsrun provides the ability to launch multiple ``jsrun`` job launches within a
+single batch job allocation. This can be done within a single node, or across
+multiple nodes.
+
+Sequential Job Steps
+^^^^^^^^^^^^^^^^^^^^
+
+By default, multiple invocations of ``jsrun`` in a job script will execute 
+serially in order. In this configuration, jobs will launch one at a time and
+the next one will not start until the previous is complete. The batch node
+allocation is equal to the largest jsrun submitted, and the total walltime
+must be equal to or greater then the *sum* of all jsruns issued.
+ 
+.. image:: /images/summit-multi-jsrun-example-sequential.png
+   :align: center
+
+Simultaneous Job Steps
+^^^^^^^^^^^^^^^^^^^^^^
+
+To execute multiple job steps concurrently, standard UNIX process
+backgrounding can be used by adding a ``&`` at the end of the command. This
+will return control to the job script and execute the next command immediately,
+allowing multiple job launches to start at the same time. The jsruns will not
+share core/gpu resources in this configuration. The batch node allocation is 
+equal to the *sum* of those of each jsrun, and the total walltime must be equal
+to or greater than that of the longest running jsrun task.
+
+A ``wait`` command must follow all backgrounded processes to prevent the job
+from appearing completed and exiting prematurely.
+
+.. image:: /images/summit-multi-jsrun-example-simultaneous.png
+   :align: center
+
+The following example executes three backgrounded job steps and waits for them
+to finish before the job ends.
+
+::
+
+    #!/bin/bash
+    #BSUB -P ABC123
+    #BSUB -W 3:00
+    #BSUB -nnodes 1
+    #BSUB -J RunSim123
+    #BSUB -o RunSim123.%J
+    #BSUB -e RunSim123.%J
+    
+    cd $MEMBERWORK/abc123
+    jsrun <options> ./a.out &
+    jsrun <options> ./a.out &
+    jsrun <options> ./a.out &
+    wait
+
+
+As submission scripts (and interactive sessions) are executed on batch nodes,
+the number of concurrent job steps is limited by the per-user process limit on
+a batch node, where a single user is only permitted 4096 simultaneous
+processes. This limit is per user on each batch node, not per batch job.
+
+Each job step will create 3 processes, and JSM management may create up to ~23
+processes. This creates an upper-limit of ~1350 simultaneous job steps. 
+
+If JSM or PMIX errors occur as the result of backgrounding many job steps, using the
+``--immediate`` option to ``jsrun`` may help, as shown in the following example.
+
+::
+
+    #!/bin/bash
+    #BSUB -P ABC123
+    #BSUB -W 3:00
+    #BSUB -nnodes 1
+    #BSUB -J RunSim123
+    #BSUB -o RunSim123.%J
+    #BSUB -e RunSim123.%J
+    
+    cd $MEMBERWORK/abc123
+    jsrun <options> --immediate ./a.out
+    jsrun <options> --immediate ./a.out 
+    jsrun <options> --immediate ./a.out
+
+
+.. note::
+    By default, ``jsrun --immediate`` does not produce ``stdout`` or
+    ``stderr``. To capture ``stdout`` and/or ``stderr`` when using this option,
+    additionally include ``--stdio_stdout``/``-o`` and/or
+    ``--stdio_stderr``/``-k``.
+
+Using `jslist`
+^^^^^^^^^^^^^^
+To view the status of multiple jobs launched sequentially or concurrently within a 
+batch script, you can use `jslist` to see which are completed, running, or still
+queued. If you are using it outside of an interactive batch job, use the `-c` option
+to specify the CSM allocation ID number. The following example shows how to obtain the
+CSM allocation number for a non interactive job and then check its status. 
+
+::
+
+    $ bsub test.lsf
+    Job <26238> is submitted to default queue <batch>.
+
+    $ bjobs -l 26238 | grep CSM_ALLOCATION_ID
+    Sun Feb 16 19:01:18: CSM_ALLOCATION_ID=34435
+
+    $ jslist -c 34435
+      parent         cpus     gpus     exit
+      ID  ID    nrs  per RS  per RS   status    status
+     ===========================================================
+       1   0    12     4       1        0       Running
+
+
+
+Explicit Resource Files (ERF)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+`Explicit Resource Files
+<https://www.ibm.com/support/knowledgecenter/en/SSWRJV_10.1.0/jsm/10.3/base/erf_format.html>`__
+provide even more fine-granied control over how processes are mapped onto
+compute nodes. ERFs can define job step options such as rank placement/binding,
+SMT/CPU/GPU resources, compute hosts, among many others. If you find that the
+most common jsrun options do not readily provide the resource layout you need,
+we recommend considering ERF files.
+
+A common source of confusion when using ERFs is how physical cores are
+enumerated. See the tutorial on `ERF CPU
+Indexing <https://github.com/olcf-tutorials/ERF-CPU-Indexing>`__ for a
+discussion of the ``cpu_index_using`` control and its interaction with various
+SMT modes.
+
+
+.. note::
+    Please note, a known bug is currently preventing execution of most ERF use cases. We are working to resolve the issue.
+
+.. _CUDA-Aware MPI:
+
+CUDA-Aware MPI
+--------------
+
+CUDA-aware MPI and GPUDirect are often used interchangeably, but they
+are distinct topics.
+
+CUDA-aware MPI allows GPU buffers (e.g., GPU memory allocated with
+``cudaMalloc``) to be used directly in MPI calls rather than requiring
+data to be manually transferred to/from a CPU buffer (e.g., using
+``cudaMemcpy``) before/after passing data in MPI calls. By itself,
+CUDA-aware MPI does not specify whether data is staged through
+CPU memory or, for example, transferred directly between GPUs when
+passing GPU buffers to MPI calls. That is where GPUDirect comes in.
+
+GPUDirect is a technology that can be implemented on a system to enhance
+CUDA-aware MPI by allowing data transfers directly between GPUs on the
+same node (peer-to-peer) and/or directly between GPUs on different nodes
+(with RDMA support) without the need to stage data through CPU memory.
+On Summit, both peer-to-peer and RDMA support are implemented. To enable
+CUDA-aware MPI in a job, use the following argument to ``jsrun``:
+
+.. code::
+
+    jsrun --smpiargs="-gpu" ...
+
+
+Not using the ``--smpiargs="-gpu"`` flag might result in confusing segmentation
+faults. If you see a segmentation fault when trying to do GPU aware MPI, check to
+see if you have the flag set correctly.
+
+
+Monitoring Jobs
+---------------
+
+LSF provides several utilities with which you can monitor jobs. These
+include monitoring the queue, getting details about a particular job,
+viewing STDOUT/STDERR of running jobs, and more.
+
+The most straightforward monitoring is with the ``bjobs`` command. This
+command will show the current queue, including both pending and running
+jobs. Running ``bjobs -l`` will provide much more detail about a job (or
+group of jobs). For detailed output of a single job, specify the job id
+after the ``-l``. For example, for detailed output of job 12345, you can
+run ``bjobs -l 12345`` . Other options to ``bjobs`` are shown below. In
+general, if the command is specified with ``-u all`` it will show
+information for all users/all jobs. Without that option, it only shows
+your jobs. Note that this is not an exhaustive list. See ``man bjobs``
+for more information.
+
++-----------------------+--------------------------------------------------------------------------------+
+| Command               | Description                                                                    |
++=======================+================================================================================+
+| ``bjobs``             | Show your current jobs in the queue                                            |
++-----------------------+--------------------------------------------------------------------------------+
+| ``bjobs -u all``      | Show currently queued jobs for all users                                       |
++-----------------------+--------------------------------------------------------------------------------+
+| ``bjobs -P ABC123``   | Shows currently-queued jobs for project ABC123                                 |
++-----------------------+--------------------------------------------------------------------------------+
+| ``bjobs -UF``         | Don't format output (might be useful if you're using the output in a script)   |
++-----------------------+--------------------------------------------------------------------------------+
+| ``bjobs -a``          | Show jobs in all states, including recently finished jobs                      |
++-----------------------+--------------------------------------------------------------------------------+
+| ``bjobs -l``          | Show long/detailed output                                                      |
++-----------------------+--------------------------------------------------------------------------------+
+| ``bjobs -l 12345``    | Show long/detailed output for jobs 12345                                       |
++-----------------------+--------------------------------------------------------------------------------+
+| ``bjobs -d``          | Show details for recently completed jobs                                       |
++-----------------------+--------------------------------------------------------------------------------+
+| ``bjobs -s``          | Show suspended jobs, including the reason(s) they're suspended                 |
++-----------------------+--------------------------------------------------------------------------------+
+| ``bjobs -r``          | Show running jobs                                                              |
++-----------------------+--------------------------------------------------------------------------------+
+| ``bjobs -p``          | Show pending jobs                                                              |
++-----------------------+--------------------------------------------------------------------------------+
+| ``bjobs -w``          | Use "wide" formatting for output                                               |
++-----------------------+--------------------------------------------------------------------------------+
+
+If you want to check the STDOUT/STDERR of a currently running job, you
+can do so with the ``bpeek`` command. The command supports several
+options:
+
++------------------------+---------------------------------------------------------------------------------------------+
+| Command                | Description                                                                                 |
++========================+=============================================================================================+
+| ``bpeek -J jobname``   | Show STDOUT/STDERR for the job you've most recently submitted with the name jobname         |
++------------------------+---------------------------------------------------------------------------------------------+
+| ``bpeek 12345``        | Show STDOUT/STDERR for job 12345                                                            |
++------------------------+---------------------------------------------------------------------------------------------+
+| ``bpeek -f ...``       | Used with other options. Makes ``bpeek`` use ``tail -f`` and exit once the job completes.   |
++------------------------+---------------------------------------------------------------------------------------------+
+
+The OLCF also provides ``jobstat``, which adds dividers in the queue to
+identify jobs as running, eligible, or blocked. Run without arguments,
+``jobstat`` provides a snapshot of the entire batch queue. Additional
+information, including the number of jobs in each state, total nodes
+available, and relative job priority are also included.
+
+``jobstat -u <username>`` restricts output to only the jobs of a
+specific user. See the ``jobstat`` man page for a full list of
+formatting arguments.
+
+::
+
+    $ jobstat -u <user>
+    --------------------------- Running Jobs: 2 (4544 of 4604 nodes, 98.70%) ---------------------------
+    JobId    Username   Project          Nodes Remain     StartTime       JobName
+    331590   user     project           2     57:06      04/09 10:06:23  Not_Specified
+    331707   user     project           40    39:47      04/09 11:04:04  runA
+    ----------------------------------------- Eligible Jobs: 3 -----------------------------------------
+    JobId    Username   Project          Nodes Walltime   QueueTime       Priority JobName
+    331712   user     project           80    45:00      04/09 11:06:23  501.00   runB
+    331713   user     project           90    45:00      04/09 11:07:19  501.00   runC
+    331714   user     project           100   45:00      04/09 11:07:49  501.00   runD
+    ----------------------------------------- Blocked Jobs: 1 ------------------------------------------
+    JobId    Username   Project          Nodes Walltime   BlockReason
+    331715   user        project           12    2:00:00    Job dependency condition not satisfied
+
+Inspecting Backfill
+^^^^^^^^^^^^^^^^^^^
+
+``bjobs`` and ``jobstat`` help to identify what’s currently running and
+scheduled to run, but sometimes it’s beneficial to know how much of the
+system is *not* currently in use or scheduled for use.
+
+The ``bslots`` command can be used to inspect backfill windows and answer
+the question “How many nodes are currently available, and for how long
+will they remain available?” This can be thought of as identifying gaps in
+the system’s current job schedule. By intentionally requesting resources
+within the parameters of a backfill window, one can potentially shorten
+their queued time and improve overall system utilization.
+
+LSF uses “slots” to describe allocatable resources. Summit compute nodes have 1
+slot per CPU core, for a total of 42 per node ([2x] Power9 CPUs, each
+with 21 cores). Since Summit nodes are scheduled in whole-node
+allocations, the output from ``bslots`` can be divided by 42 to see how
+many nodes are currently available.
+
+By default, ``bslots`` output includes launch node slots, which can
+cause unwanted and inflated fractional node values. The output can
+be adjusted to reflect only available compute node slots with the
+flag  ``-R”select[CN]”``. For example,
+
+::
+
+    $ bslots -R"select[CN]"
+    SLOTS          RUNTIME
+    42             25 hours 42 minutes 51 seconds
+    27384          1 hours 11 minutes 50 seconds
+
+27384 compute node slots / 42 slots per node = 652 compute nodes are
+available for 1 hour, 11 minutes, 50 seconds.
+
+A more specific ``bslots`` query could check for a backfill window with
+space to fit a 1000 node job for 10 minutes:
+
+::
+
+    $ bslots -R"select[CN]" -n $((1000*42)) -W10
+    SLOTS          RUNTIME
+    127764         22 minutes 55 seconds
+
+There is no guarantee that the slots reported by ``bslots`` will still
+be available at time of new job submission.
+
+Interacting With Jobs
+---------------------
+
+Sometimes it’s necessary to interact with a batch job after it has been
+submitted. LSF provides several commands for interacting with
+already-submitted jobs.
+
+Many of these commands can operate on either one job or a group of jobs.
+In general, they only operate on the most recently submitted job that
+matches other criteria provided unless “0” is specified as the job id.
+
+Suspending and Resuming Jobs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+LSF supports user-level suspension and resumption of jobs. Jobs are
+suspended with the ``bstop`` command and resumed with the ``bresume``
+command. The simplest way to invoke these commands is to list the job id
+to be suspended/resumed:
+
+.. code::
+
+    bstop 12345
+    bresume 12345
+
+Instead of specifying a job id, you can specify other criteria that will
+allow you to suspend some/all jobs that meet other criteria such as a
+job name, a queue name, etc. These are described in the manpages for
+``bstop`` and ``bresume``.
+
+Signaling Jobs
+^^^^^^^^^^^^^^
+
+You can send signals to jobs with the ``bkill`` command. While the
+command name suggests its only purpose is to terminate jobs, this is not
+the case. Similar to the ``kill`` command found in Unix-like operating
+systems, this command can be used to send various signals (not just
+``SIGTERM`` and ``SIGKILL``) to jobs. The command can accept both
+numbers and names for signals. For a list of accepted signal names, run
+``bkill -l``. Common ways to invoke the command include:
+
+.. table::
+    :widths: 17 83
+
+    +---------------------------+----------------------------------------------------------------------------------+
+    | Command                   | Description                                                                      |
+    +===========================+==================================================================================+
+    | ``bkill 12345``           | Force a job to stop by sending ``SIGINT``,                                       |
+    |                           | ``SIGTERM``, and ``SIGKILL``. These signals are sent in that order, so users     |
+    |                           | can write applications such that they will trap ``SIGINT`` and/or ``SIGTERM``    |
+    |                           | and exit in a controlled manner.                                                 |
+    +---------------------------+----------------------------------------------------------------------------------+
+    | ``bkill -s USR1 12345``   | Send ``SIGUSR1`` to job 12345 NOTE: When                                         |
+    |                           | specifying a signal by name, omit SIG from the name. Thus, you specify ``USR1``  |
+    |                           | and not ``SIGUSR1`` on the ``bkill`` command line.                               |
+    +---------------------------+----------------------------------------------------------------------------------+
+    | ``bkill -s 9 12345``      | Send signal 9 to job 12345                                                       |
+    +---------------------------+----------------------------------------------------------------------------------+
+
+Like ``bstop`` and ``bresume``, ``bkill`` command also supports
+identifying the job(s) to be signaled by criteria other than the job id.
+These include some/all jobs with a given name, in a particular queue,
+etc. See ``man bkill`` for more information.
+
+Checkpointing Jobs
+^^^^^^^^^^^^^^^^^^
+
+LSF documentation mentions the ``bchkpnt`` and ``brestart`` commands for
+checkpointing and restarting jobs, as well as the ``-k`` option to
+``bsub`` for configuring checkpointing. Since checkpointing is very
+application specific and a wide range of applications run on OLCF
+resources, this type of checkpointing is not configured on Summit. If
+you wish to use checkpointing (which is highly encouraged), you’ll need
+to configure it within your application.
+
+If you wish to implement some form of on-demand checkpointing, keep in mind
+the ``bkill`` command is really a signaling command and you can have your
+job script/application checkpoint as a response to certain signals (such
+as ``SIGUSR1``).
+
+Other LSF Commands
+------------------
+
+The table below summarizes some additional LSF commands that might be
+useful.
+
+.. table::
+    :widths: 12 88
+
+    +------------------+---------------------------------------------------------------------------+
+    | Command          | Description                                                               |
+    +==================+===========================================================================+
+    | ``bparams -a``   | Show current parameters for LSF. The behavior/available                   |
+    |                  | options for some LSF commands depend on settings in various configuration |
+    |                  | files. This command shows those settings without having to search for the |
+    |                  | actual files.                                                             |
+    +------------------+---------------------------------------------------------------------------+
+    | ``bjdepinfo``    | Show job dependency information (could be useful in                       |
+    |                  | determining what job is keeping another job in a pending state)           |
+    +------------------+---------------------------------------------------------------------------+
+
+PBS/Torque/MOAB-to-LSF Translation
+----------------------------------
+
+More details about these commands are given elsewhere in this section;
+the table below is simply for your convenience in looking up various LSF
+commands.
+
+Users of other OLCF resources are likely familiar with
+PBS-like commands which are used by the Torque/Moab instances on other
+systems. The table below summarizes the equivalent LSF command for
+various PBS/Torque/Moab commands.
+
++--------------------------+----------------------------------+----------------------------------------------------+
+| LSF Command              | PBS/Torque/Moab Command          | Description                                        |
++==========================+==================================+====================================================+
+| ``bsub job.sh``          | ``qsub job.sh``                  | Submit the job script job.sh to the batch system   |
++--------------------------+----------------------------------+----------------------------------------------------+
+| ``bsub -Is /bin/bash``   | ``qsub -I``                      | Submit an interactive batch job                    |
++--------------------------+----------------------------------+----------------------------------------------------+
+| ``bjobs -u all``         | ``qstat showq``                  | Show jobs currently in the queue NOTE: without the |
+|                          |                                  | -u all argument, bjobs will only show your jobs    |
++--------------------------+----------------------------------+----------------------------------------------------+
+| ``bjobs -l``             | ``checkjob``                     | Get information about a specific job               |
++--------------------------+----------------------------------+----------------------------------------------------+
+| ``bjobs -d``             | ``showq -c``                     | Get information about completed jobs               |
++--------------------------+----------------------------------+----------------------------------------------------+
+| ``bjobs -p``             | ``showq -i``                     | Get information about pending jobs                 |
+|                          | ``showq -b``                     |                                                    |
+|                          | ``checkjob``                     |                                                    |
++--------------------------+----------------------------------+----------------------------------------------------+
+| ``bjobs -r``             | ``showq -r``                     | Get information about running jobs                 |
++--------------------------+----------------------------------+----------------------------------------------------+
+| ``bkill``                | ``qsig``                         | Send a signal to a job                             |
++--------------------------+----------------------------------+----------------------------------------------------+
+| ``bkill``                | ``qdel``                         | Terminate/Kill a job                               |
++--------------------------+----------------------------------+----------------------------------------------------+
+| ``bstop``                | ``qhold``                        | Hold a job/stop a job from running                 |
++--------------------------+----------------------------------+----------------------------------------------------+
+| ``bresume``              | ``qrls``                         | Release a held job                                 |
++--------------------------+----------------------------------+----------------------------------------------------+
+| ``bqueues``              | ``qstat -q``                     | Get information about queues                       |
++--------------------------+----------------------------------+----------------------------------------------------+
+| ``bjdepinfo``            | ``checkjob``                     | Get information about job dependencies             |
++--------------------------+----------------------------------+----------------------------------------------------+
+
+The table below shows shows LSF (bsub) command-line/batch script options
+and the PBS/Torque/Moab (qsub) options that provide similar
+functionality.
+
++---------------------------------+------------------------------------------------+------------------------------------------------------------+
+| LSF Option                      | PBS/Torque/Moab Option                         | Description                                                |
++=================================+================================================+============================================================+
+| ``#BSUB -W 60``                 | ``#PBS -l walltime=1:00:00``                   | Request a walltime of 1 hour                               |
++---------------------------------+------------------------------------------------+------------------------------------------------------------+
+| ``#BSUB -nnodes 1024``          | ``#PBS -l nodes=1024``                         | Request 1024 nodes                                         |
++---------------------------------+------------------------------------------------+------------------------------------------------------------+
+| ``#BSUB -P ABC123``             | ``#PBS -A ABC123``                             | Charge the job to project ABC123                           |
++---------------------------------+------------------------------------------------+------------------------------------------------------------+
+| ``#BSUB -alloc_flags gpumps``   | No equivalent (set via environment variable)   | Enable multiple MPI tasks to simultaneously access a GPU   |
++---------------------------------+------------------------------------------------+------------------------------------------------------------+
+
+.. _easy_mode_v_expert_mode:
+
+Easy Mode vs. Expert Mode
+-------------------------
+
+The Cluster System Management (CSM) component of the job launch
+environment supports two methods of job submission, termed “easy” mode
+and “expert” mode. The difference in the modes is where the
+responsibility for creating the LSF resource string is placed.
+
+In easy mode, the system software converts options such as -nnodes in
+a batch script into the resource string needed by the scheduling system.
+In expert mode, the user is responsible for creating this string and
+options such as -nnodes cannot be used. In easy mode, you will not be
+able to use ``bsub -R`` to create resource strings. The system will
+automatically create the resource string based on your other ``bsub``
+options. In expert mode, you will be able to use ``-R``, but you will
+not be able to use the following options to ``bsub``: ``-ln_slots``,
+``-ln_mem``, ``-cn_cu``, or ``-nnodes``.
+
+Most users will want to use easy mode. However, if you need precise
+control over your job’s resources, such as placement on (or avoidance
+of) specific nodes, you will need to use expert mode. To use expert
+mode, add ``#BSUB -csm y`` to your batch script (or ``-csm y`` to
+your ``bsub`` command line).
+
+
+System Service Core Isolation
+-----------------------------
+
+One core per socket is set aside for system service tasks. The cores are
+not available to jsrun. When listing available resources through jsrun,
+you will not see cores with hyperthreads 84-87 and 172-175. Isolating a
+socket's system services to a single core helps to reduce jitter and
+improve performance of tasks performed on the socket's remaining cores.
+
+The isolated core always operates at SMT4 regardless of the batch job's
+SMT level.
+
+GPFS System Service Isolation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, GPFS system service tasks are forced onto only the isolated
+cores. This can be overridden at the batch job level using the
+``maximizegpfs`` argument to LSF's ``alloc_flags``. For example:
+
+::
+
+     #BSUB -alloc_flags maximizegpfs
+
+The maximizegpfs flag will allow GPFS tasks to utilize any core on the
+compute node. This may be beneficial because it provides more resources
+for GPFS service tasks, but it may also cause resource contention for
+the jsrun compute job.
+
+Job Accounting on Summit
+------------------------
+
+Jobs on Summit are scheduled in full node increments; a node's cores cannot be
+allocated to multiple jobs. Because the OLCF charges based on what a job makes
+*unavailable* to other users, a job is charged for an entire node even if it
+uses only one core on a node. To simplify the process, users request and are allocated
+multiples of entire nodes through LSF.
+
+Allocations on Summit are separate from those on Andes and other OLCF resources.
+
+Node-Hour Calculation
+^^^^^^^^^^^^^^^^^^^^^
+
+The *node-hour* charge for each batch job will be calculated as follows:
+
+.. code::
+
+    node-hours = nodes requested * ( batch job endtime - batch job starttime )
+
+Where *batch job starttime* is the time the job moves into a running state, and
+*batch job endtime* is the time the job exits a running state.
+
+A batch job's usage is calculated solely on requested nodes and the batch job's
+start and end time. The number of cores actually used within any particular node
+within the batch job is not used in the calculation. For example, if a job
+requests (6) nodes through the batch script, runs for (1) hour, uses only (2)
+CPU cores per node, the job will still be charged for 6 nodes \* 1 hour = *6
+node-hours*.
+
+Viewing Usage
+^^^^^^^^^^^^^
+
+Utilization is calculated daily using batch jobs which complete between 00:00
+and 23:59 of the previous day. For example, if a job moves into a run state on
+Tuesday and completes Wednesday, the job's utilization will be recorded
+Thursday. Only batch jobs which write an end record are used to calculate
+utilization. Batch jobs which do not write end records due to system failure or
+other reasons are not used when calculating utilization. Jobs which fail because
+of run-time errors (e.g. the user's application causes a segmentation fault) are
+counted against the allocation.
+
+Each user may view usage for projects on which they are members from the command
+line tool ``showusage`` and the `myOLCF site <https://my.olcf.ornl.gov>`__.
+
+On the Command Line via ``showusage``
+"""""""""""""""""""""""""""""""""""""
+
+The ``showusage`` utility can be used to view your usage from January 01
+through midnight of the previous day. For example:
+
+.. code::
+
+      $ showusage
+        Usage:
+                                 Project Totals
+        Project             Allocation      Usage      Remaining     Usage
+        _________________|______________|___________|____________|______________
+        abc123           |  20000       |   126.3   |  19873.7   |   1560.80
+
+The ``-h`` option will list more usage details.
+
+On the Web via myOLCF
+""""""""""""""""""""""
+
+More detailed metrics may be found on each project's usage section of the `myOLCF
+site <https://my.olcf.ornl.gov>`__. The following information is available
+for each project:
+
+-  YTD usage by system, subproject, and project member
+-  Monthly usage by system, subproject, and project member
+-  YTD usage by job size groupings for each system, subproject, and
+   project member
+-  Weekly usage by job size groupings for each system, and subproject
+-  Batch system priorities by project and subproject
+-  Project members
+
+The myOLCF site is provided to aid in the utilization and management of OLCF
+allocations. See the :doc:`myOLCF Documentation </services_and_applications/myolcf/index>` for more information.
+
+If you have any questions or have a request for additional data,
+please contact the OLCF User Assistance Center.
+
+
+
+Other Notes
+-----------
+
+Compute nodes are only allocated to one job at a time; they are not
+shared. This is why users request nodes (instead of some other resource
+such as cores or GPUs) in batch jobs and is why projects are charged
+based on the number of nodes allocated multiplied by the amount of time
+for which they were allocated. Thus, a job using only 1 core on each of
+its nodes is charged the same as a job using every core and every GPU on
+each of its nodes.
+
+
+
+.. _debugging:
+
+Debugging
+=========
+
+Linaro DDT
+----------
+
+Linaro DDT is an advanced debugging tool used for scalar, multi-threaded,
+and large-scale parallel applications. In addition to traditional
+debugging features (setting breakpoints, stepping through code,
+examining variables), DDT also supports attaching to already-running
+processes and memory debugging. In-depth details of DDT can be found in
+the `Official DDT User Guide <https://www.linaroforge.com/documentation/>`__, and
+instructions for how to use it on OLCF systems can be found on the :doc:`Debugging Software </software/debugging/index>` page. DDT is the
+OLCF's recommended debugging software for large parallel applications.
+
+One of the most useful features of DDT is its remote debugging feature. This allows you to connect to a debugging session on Frontier from a client running on your workstation. The local client provides much faster interaction than you would have if using the graphical client on Frontier. For guidance in setting up the remote client see the :doc:`Debugging Software </software/debugging/index>` page.
+
+GDB
+---
+
+`GDB <https://www.gnu.org/software/gdb/>`__, the GNU Project Debugger,
+is a command-line debugger useful for traditional debugging and
+investigating code crashes. GDB lets you debug programs written in Ada,
+C, C++, Objective-C, Pascal (and many other languages). 
+
+GDB is available on Summit under all compiler families:
+
+.. code::
+
+    module load gdb
+
+To use GDB to debug your application run:
+
+.. code::
+
+    gdb ./path_to_executable
+
+Additional information about GDB usage can befound on the `GDB Documentation Page <https://www.sourceware.org/gdb/documentation/>`__.
+
+
+Valgrind
+--------
+
+`Valgrind <http://valgrind.org>`__ is an instrumentation framework for
+building dynamic analysis tools. There are Valgrind tools that can
+automatically detect many memory management and threading bugs, and
+profile your programs in detail. You can also use Valgrind to build new
+tools.
+
+The Valgrind distribution currently includes five production-quality
+tools: a memory error detector, a thread error detector, a cache and
+branch-prediction profiler, a call-graph generating cache profiler,
+and a heap profiler. It also includes two experimental tools: a data
+race detector, and an instant memory leak detector.
+
+The Valgrind tool suite provides a number of debugging and
+profiling tools. The most popular is Memcheck, a memory checking tool
+which can detect many common memory errors such as:
+
+- Touching memory you shouldn’t (eg. overrunning heap block boundaries,
+  or reading/writing freed memory).
+- Using values before they have been initialized.
+- Incorrect freeing of memory, such as double-freeing heap blocks.
+- Memory leaks.
+
+Valgrind is available on Summit under all compiler families:
+
+.. code::
+
+    module load valgrind
+
+Additional information about Valgrind usage and OLCF-provided builds can
+be found on the `Valgrind Software
+Page <https://www.olcf.ornl.gov/software_package/valgrind/>`__.
+
+.. _optimizing-and-profiling:
+
+Optimizing and Profiling
+========================
+
+Profiling GPU Code with NVIDIA Developer Tools
+-----------------------------------------------------
+
+NVIDIA provides developer tools for profiling any code that runs on NVIDIA
+GPUs. These are the `Nsight suite of developer tools
+<https://developer.nvidia.com/tools-overview>`__: NVIDIA Nsight Systems for
+collecting a timeline of your application, and NVIDIA Nsight Compute for
+collecting detailed performance information about specific GPU kernels.
+
+NVIDIA Nsight Systems
+^^^^^^^^^^^^^^^^^^^^^
+
+The first step to GPU profiling is collecting a timeline of your application.
+(This operation is also sometimes called "tracing," that is, finding
+the start and stop timestamps of all activities that occurred on the GPU
+or involved the GPU, such as copying data back and forth.) To do this, we
+can collect a timeline using the command-line interface, ``nsys``. To use
+this tool, load the ``nsight-systems`` module.
+
+::
+
+    summit> module load nsight-systems
+
+For example, we can profile the ``vectorAdd`` CUDA sample (the CUDA samples
+can be found in ``$OLCF_CUDA_ROOT/samples`` if the ``cuda`` module is loaded.)
+
+::
+
+    summit> jsrun -n1 -a1 -g1 nsys profile -o vectorAdd --stats=true ./vectorAdd
+
+(Note that even if you do not ask for Nsight Systems to create an output file,
+but just ask it to print summary statistics with ``--stats=true``, it will create
+a temporary file for storing the profiling data, so you will need to work on a
+file system that can be written to from a compute node such as GPFS.)
+
+The profiler will print several sections including information about the
+CUDA API calls made by the application, as well as any GPU kernels that were
+launched. Nsight Systems can be used for CUDA C++, CUDA Fortran, OpenACC,
+OpenMP offload, and other programming models that target NVIDIA GPUs, because
+under the hood they all ultimately take the same path for generating the binary
+code that runs on the GPU.
+
+If you add the ``-o`` option, as above, the report will be saved to file
+with the extension ``.qdrep``. That report file can later be analyzed in
+the Nsight Systems UI by selecting File > Open and locating the ``vectorAdd.qdrep``
+file on your filesystem. Nsight Systems does not currently have a Power9
+version of the UI, so you will need to `download the UI for your local system
+<https://developer.nvidia.com/nsight-systems>`__, which is supported on
+Windows, Mac, and Linux (x86). Then use ``scp`` or some other file transfer
+utility for copying the report file from Summit to your local machine.
+
+Nsight Systems can be used for MPI runs with multiple ranks, but it is
+not a parallel profiler and cannot combine output from multiple ranks.
+Instead, each rank must be profiled and analyzed independently. The file
+name should be unique for every rank. Nsight Systems knows how to parse
+environment variables with the syntax ``%q{ENV_VAR}``, and since Spectrum
+MPI provides an environment variable for every process with its MPI rank,
+you can do
+
+::
+
+    summit> jsrun -n6 -a1 -g1 nsys profile -o vectorAdd_%q{OMPI_COMM_WORLD_RANK} ./vectorAdd
+
+Then you will have ``vectorAdd_0.qdrep`` through ``vectorAdd_5.qdrep``.
+(Of course, in this case each rank does the same thing as this is not
+an MPI application, but it works the same way for an MPI code.)
+
+For more details about Nsight Systems, consult the `product page
+<https://developer.nvidia.com/nsight-systems>`__ and the `documentation
+<https://docs.nvidia.com/nsight-systems/index.html>`__. If you previously
+used ``nvprof`` and would like to start using the Nsight Developer Tools,
+check out `this transition guide
+<https://devblogs.nvidia.com/migrating-nvidia-nsight-tools-nvvp-nvprof/>`__.
+Also, in March 2020 NVIDIA presented a webinar on Nsight Systems which you
+can `watch on demand <https://www.olcf.ornl.gov/calendar/nvidia-profiling-tools-nsight-systems/>`__.
+
+NVIDIA Nsight Compute
+^^^^^^^^^^^^^^^^^^^^^
+
+Individual GPU kernels (the discrete chunks of work that are launched by
+programming languages such as CUDA and OpenACC) can be profiled in detail
+with NVIDIA Nsight Compute. The typical workflow is to profile your code
+with Nsight Systems and identify the major performance bottleneck in your
+application. If that performance bottleneck is on the CPU, it means more
+code should be ported to the GPU; or, if that bottleneck is in memory
+management, such as copying data back and forth between the CPU and GPU,
+you should look for opportunities to reduce that data motion. But if that
+bottleneck is a GPU kernel, then Nsight Compute can be used to collect
+performance counters to understand whether the kernel is running efficiently
+and if there's anything you can do to improve.
+
+The Nsight Compute command-line interface, ``nv-nsight-cu-cli``, can be
+prefixed to your application to collect a report.
+
+::
+
+    summit> module load nsight-compute
+
+::
+
+    summit> jsrun -n1 -a1 -g1 nv-nsight-cu-cli ./vectorAdd
+
+Similar to Nsight Systems, Nsight Compute will create a temporary report file,
+even when ``-o`` is not specified.
+
+The most important output to look at is the "GPU Speed of Light" section,
+which tells you what fraction of peak memory throughput and what fraction
+of peak compute throughput you achieved. Typically if you have achieved
+higher than 60% of the peak of either subsystem, your kernel would be
+considered memory-bound or compute-bound (respectively), and if you have
+not achieved 60% of either this is often a latency-bound kernel. (A common
+cause of latency issues is not exposing enough parallelism to saturate
+the GPU's compute capacity -- peak GPU performance can only be achieved when
+there is enough work to hide the latency of memory accesses and to keep all
+compute pipelines busy.)
+
+
+By default, Nsight Compute will collect this performance data for every kernel
+in your application. This will take a long time in a real-world application.
+It is recommended that you identify a specific kernel to profile and then use
+the ``-k`` argument to just profile that kernel. (If you don't know the name of
+your kernel, use ``nsys`` to obtain that. The flag will pattern match on any
+substring of the kernel name.) You can also use the ``-s`` option to skip some
+number of kernel calls and the ``-c`` option to specify how many invocations of
+that kernel you want to profile.
+
+If you want to collect information on just a specific performance measurement,
+for example the number of bytes written to DRAM, you can do so with the
+``--metrics`` option:
+
+::
+
+    summit> jsrun -n1 -a1 -g1 nv-nsight-cu-cli -k vectorAdd --metrics dram__bytes_write.sum ./vectorAdd
+
+The list of available metrics can be obtained with ``nv-nsight-cu-cli
+--query-metrics``. Most metrics have both a base name and suffix. Together
+these  make up the full metric name to pass to ``nv-nsight-cu-cli``. To list
+the full names for a collection of metrics, use ``--query-metrics-mode suffix
+--metrics <metrics list>``.
+
+
+As with Nsight Systems, there is a graphical user interface you can load a
+report file into (The GUI is only available for Windows, x86_64 Linux and Mac).
+Use the ``-o`` flag to create a file (the added report extension will be
+``.nsight-cuprof-report``), copy it to your local system, and use the File >
+Open File menu item. If you are using multiple MPI ranks, make sure you name
+each one independently. Nsight Compute does not yet support the ``%q`` syntax
+(this will come in a future release), so your job script will have to do the
+naming manually; for example, you can create a simple shell script:
+
+::
+
+    $ cat run.sh
+    #!/bin/bash
+
+    nv-nsight-cu-cli -o vectorAdd_$OMPI_COMM_WORLD_RANK ./vectorAdd
+
+For more details on Nsight Compute, check out the `product page
+<https://developer.nvidia.com/nsight-compute>`__ and the `documentation
+<https://docs.nvidia.com/nsight-compute/index.html>`__. If you previously used
+``nvprof`` and would like to start using Nsight Compute, check out `this transition
+guide <https://docs.nvidia.com/nsight-compute/NsightComputeCli/index.html#nvprof-guide>`__.
+Also, in March 2020 NVIDIA presented a webinar on Nsight Compute which you can `watch on
+demand <https://www.olcf.ornl.gov/calendar/nvidia-profiling-tools-nsight-compute/>`__.
+
+nvprof and nvvp
+^^^^^^^^^^^^^^^
+
+Prior to Nsight Systems and Nsight Compute, the NVIDIA command line profiling
+tool was ``nvprof``, which provides both tracing and kernel profiling
+capabilities. Like with Nsight Systems and Nsight Compute, the profiler data
+output can be saved and imported into the NVIDIA Visual Profiler for additional
+graphical analysis. ``nvprof`` is in maintenance mode now: it still works on
+Summit and significant bugs will be fixed, but no new feature development is
+occurring on this tool.
+
+To use ``nvprof``, the ``cuda`` module must be loaded.
+
+::
+
+    summit> module load cuda
+
+A simple "Hello, World!" run using ``nvprof`` can be done by adding
+"nvprof" to the jsrun (see: :ref:`job-launcher-jsrun`)
+line in your batch script (see :ref:`batch-scripts`).
+
+::
+
+    ...
+    jsrun -n1 -a1 -g1 nvprof ./hello_world_gpu
+    ...
+
+Although ``nvprof`` doesn't provide aggregated MPI data, the ``%h`` and
+``%p`` output file modifiers can be used to create separate output files
+for each host and process.
+
+::
+
+    ...
+    jsrun -n1 -a1 -g1 nvprof -o output.%h.%p ./hello_world_gpu
+    ...
+
+There are many various metrics and events that the profiler can capture.
+For example, to output the number of double-precision FLOPS, you may use
+the following:
+
+::
+
+    ...
+    jsrun -n1 -a1 -g1 nvprof --metrics flops_dp -o output.%h.%p ./hello_world_gpu
+    ...
+
+To see a list of all available metrics and events, use the following:
+
+::
+
+    summit> nvprof --query-metrics
+    summit> nvprof --query-events
+
+While using ``nvprof`` on the command-line is a quick way to gain
+insight into your CUDA application, a full visual profile is often even
+more useful. For information on how to view the output of ``nvprof`` in
+the NVIDIA Visual Profiler, see the `NVIDIA
+Documentation <http://docs.nvidia.com/cuda/profiler-users-guide/#nvprof-overview>`__.
+
+Score-P
+-------
+
+The `Score-P <http://score-p.org/>`__ measurement infrastructure is a
+highly scalable and easy-to-use tool suite for profiling, event
+tracing, and online analysis of HPC applications. Score-P supports
+analyzing C, C++ and Fortran applications that make use of
+multi-processing (MPI, SHMEM), thread parallelism (OpenMP, PThreads) and
+accelerators (CUDA, OpenCL, OpenACC) and combinations.
+
+For detailed information about using Score-P on Summit and the
+builds available, please see the
+`Score-P Software Page. <https://www.olcf.ornl.gov/software_package/score-p/>`__
+
+Vampir
+------
+
+`Vampir <http://vampir.eu/>`__ is a software performance visualizer focused on highly
+parallel applications. It presents a unified view on an application
+run including the use of programming paradigms like MPI, OpenMP,
+PThreads, CUDA, OpenCL and OpenACC. It also incorporates file I/O,
+hardware performance counters and other performance data sources.
+Various interactive displays offer detailed insight into the performance
+behavior of the analyzed application. Vampir’s scalable analysis
+server and visualization engine enable interactive navigation of
+large amounts of performance data. `Score-P <https://olcf.ornl.gov/software_package/score-p>`__
+and `TAU <https://www.olcf.ornl.gov/software_package/tau>`__ generate OTF2
+trace files for Vampir to visualize.
+
+For detailed information about using Vampir on Summit and the builds available,
+please see the `Vampir Software Page <https://www.olcf.ornl.gov/software_package/vampir/>`__.
+
+HPCToolkit
+----------
+
+`HPCToolkit <http://hpctoolkit.org/>`__ is an integrated suite of tools for measurement and analysis of program performance on computers ranging from multicore desktop systems to the nation’s largest supercomputers. HPCToolkit provides accurate measurements of a program’s work, resource consumption, and inefficiency, correlates these metrics with the program’s source code, works with multilingual, fully optimized binaries, has very low measurement overhead, and scales to large parallel systems. HPCToolkit’s measurements provide support for analyzing a program execution cost, inefficiency, and scaling characteristics both within and across nodes of a parallel system.
+
+Programming models supported by HPCToolkit include MPI, OpenMP, OpenACC, CUDA, OpenCL, DPC++, HIP, RAJA, Kokkos, and others.
+
+Below is an example that generates a profile and loads the results in their GUI-based viewer.
+
+.. code:: bash
+
+    module use /gpfs/alpine/csc322/world-shared/modulefiles/ppc64le
+    module load hpctoolkit
+
+    # 1. Profile and trace an application using CPU time and GPU performance counters
+    jsrun <jsrun_options> hpcrun -o <measurement_dir> -t -e CPUTIME -e gpu=nvidia <application>
+
+    # 2. Analyze the binary of executables and its dependent libraries
+    hpcstruct <measurement_dir>
+
+    # 3. Combine measurements with program structure information and generate a database
+    hpcprof -o <database_dir> <measurement_dir>
+
+    # 4. Understand performance issues by analyzing profiles and traces with the GUI
+    hpcviewer <database_dir>
+
+A quick summary of HPCToolkit options can be found in the `HPCTookit wiki page <https://gitlab.com/hpctoolkit/hpctoolkit/-/wikis/HPCToolkit-cheat-sheet>`__. More detailed information on HPCToolkit can be found in the `HPCToolkit User's Manual <http://hpctoolkit.org/manual/HPCToolkit-users-manual.pdf>`__.
+
+.. note::
+
+    HPCToolkit does not require a recompile to profile the code. It is recommended to use the -g optimization flag for attribution to source lines.
+
+.. _nvidia-v100-gpus:
+.. _NVIDIA Tesla V100:
+
+NVIDIA V100 GPUs
+================
+
+The NVIDIA Tesla V100 accelerator has a peak performance of 7.8 TFLOP/s
+(double-precision) and contributes to a majority of the computational
+work performed on Summit. Each V100 contains 80 streaming
+multiprocessors (SMs), 16 GB (32 GB on high-memory nodes) of high-bandwidth
+memory (HBM2), and a 6 MB L2 cache that is available to the SMs. The
+GigaThread Engine is responsible for distributing work among the SMs and
+(8) 512-bit memory controllers control access to the 16 GB (32 GB on
+high-memory nodes) of HBM2 memory. The V100 uses NVIDIA's NVLink interconnect
+to pass data between GPUs as well as from CPU-to-GPU.
+
+.. image:: /images/GV100_FullChip_Diagram_FINAL2_a.png
+   :align: center
+
+NVIDIA V100 SM
+--------------
+
+Each SM on the V100 contains 32 FP64 (double-precision) cores, 64 FP32
+(single-precision) cores, 64 INT32 cores, and 8 tensor cores. A 128-KB
+combined memory block for shared memory and L1 cache can be configured
+to allow up to 96 KB of shared memory. In addition, each SM has 4
+texture units which use the (configured size of the) L1 cache.
+
+.. image:: /images/GV100_SM_Diagram-FINAL2.png
+   :align: center
+
+HBM2
+----
+
+Each V100 has access to 16 GB (32GB for high-memory nodes) of
+high-bandwidth memory (HBM2), which can be accessed at speeds of 
+up to 900 GB/s. Access to this memory is controlled by (8) 512-bit
+memory controllers, and all accesses to the high-bandwidth memory
+go through the 6 MB L2 cache.
+
+NVIDIA NVLink
+-------------
+
+The processors within a node are connected by NVIDIA's NVLink
+interconnect. Each link has a peak bandwidth of 25 GB/s (in each
+direction), and since there are 2 links between processors, data can be
+transferred from GPU-to-GPU and CPU-to-GPU at a peak rate of 50 GB/s.
+
+.. note::
+    The 50-GB/s peak bandwidth stated above is for data transfers
+    in a single direction. However, this bandwidth can be achieved in both
+    directions simultaneously, giving a peak "bi-directional" bandwidth of
+    100 GB/s between processors.
+
+The figure below shows a schematic of the NVLink connections between the
+CPU and GPUs on a single socket of a Summit node.
+
+.. image:: /images/NVLink2.png
+   :align: center
+
+Volta Multi-Process Service
+---------------------------
+
+When a CUDA program begins, each MPI rank creates a separate CUDA
+context on the GPU, but the scheduler on the GPU only allows one CUDA
+context (and so one MPI rank) at a time to launch on the GPU. This means
+that multiple MPI ranks can share access to the same GPU, but each rank
+gets exclusive access while the other ranks wait (time-slicing). This
+can cause the GPU to become underutilized if a rank (that has exclusive
+access) does not perform enough work to saturate the resources of the
+GPU. The following figure depicts such time-sliced access to a pre-Volta
+GPU.
+
+.. image:: /images/nv_mps_1.png
+   :align: center
+
+The Multi-Process Service (MPS) enables multiple processes (e.g. MPI ranks) to
+*concurrently* share the resources on a single GPU. This is accomplished by
+starting an MPS server process, which funnels the work from multiple CUDA
+contexts (e.g. from multiple MPI ranks) into a single CUDA context. In some
+cases, this can increase performance due to better utilization of the resources.
+The figure below illustrates MPS on a pre-Volta GPU.
+
+.. image:: /images/nv_mps_2.png
+   :width: 65.0%
+   :align: center
+
+Volta GPUs improve MPS with new capabilities. For instance, each Volta
+MPS client (MPI rank) is assigned a "subcontext" that has its own GPU
+address space, instead of sharing the address space with other clients.
+This isolation helps protect MPI ranks from out-of-range reads/writes
+performed by other ranks within CUDA kernels. Because each subcontext
+manages its own GPU resources, it can submit work directly to the GPU
+without the need to first pass through the MPS server. In addition,
+Volta GPUs support up to 48 MPS clients (up from 16 MPS clients on
+Pascal).
+
+.. image:: /images/nv_mps_3.png
+   :width: 65.0%
+   :align: center
+
+For more information, please see the following document from NVIDIA:
+https://docs.nvidia.com/deploy/pdf/CUDA_Multi_Process_Service_Overview.pdf
+
+Unified Memory
+--------------
+
+Unified memory is a single virtual address space that is accessible to
+any processor in a system (within a node). This means that programmers
+only need to allocate a single unified-memory pointer (e.g. using
+cudaMallocManaged) that can be accessed by both the CPU and GPU, instead
+of requiring separate allocations for each processor. This "managed
+memory" is automatically migrated to the accessing processor, which
+eliminates the need for explicit data transfers.
+
+.. image:: /images/nv_um_1.png
+   :width: 60.0%
+   :align: center
+
+On Pascal-generation GPUs and later, this automatic migration is
+enhanced with hardware support. A page migration engine enables GPU page
+faulting, which allows the desired pages to be migrated to the GPU "on
+demand" instead of the entire "managed" allocation. In addition, 49-bit
+virtual addressing allows programs using unified memory to access the
+full system memory size. The combination of GPU page faulting and larger
+virtual addressing allows programs to oversubscribe the system memory,
+so very large data sets can be processed. In addition, new CUDA API
+functions introduced in CUDA8 allow users to fine tune the use of
+unified memory.
+
+Unified memory is further improved on Volta GPUs through
+the use of access counters that can be used to automatically tune
+unified memory by determining where a page is most often accessed.
+
+For more information, please see the following section of NVIDIA's
+CUDA Programming Guide:
+http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#um-unified-memory-programming-hd
+
+Independent Thread Scheduling
+-----------------------------
+
+The V100 supports independent thread scheduling, which allows threads to
+synchronize and cooperate at sub-warp scales. Pre-Volta GPUs implemented
+warps (groups of 32 threads which execute instructions in
+single-instruction, multiple thread - SIMT - mode) with a single call
+stack and program counter for a warp as a whole.
+
+.. image:: /images/nv_ind_threads_1.png
+   :align: center
+
+Within a warp, a mask is used to specify which threads are currently
+active when divergent branches of code are encountered. The (active)
+threads within each branch execute their statements serially before
+threads in the next branch execute theirs. This means that programs on
+pre-Volta GPUs should avoid sub-warp synchronization; a sync point in
+the branches could cause a deadlock if all threads in a warp do not
+reach the synchronization point.
+
+.. image:: /images/nv_ind_threads_2.png
+   :align: center
+
+The Tesla V100 introduces warp-level synchronization by implementing warps with
+a program counter and call stack for each individual thread (i.e.  independent
+thread scheduling).
+
+.. image:: /images/nv_ind_threads_3.png
+   :align: center
+
+This implementation allows threads to diverge and synchronize at the sub-warp
+level using the \_\_syncwarp() function. The independent thread scheduling
+enables the thread scheduler to stall execution of any thread, allowing other
+threads in the warp to execute different statements. This means that threads in
+one branch can stall at a sync point and wait for the threads in the other
+branch to reach their sync point.
+
+.. image:: /images/nv_ind_threads_4.png
+   :align: center
+
+For more information, please see the following section of NVIDIA's CUDA
+Programming Guide:
+http://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#independent-thread-scheduling-7-x
+
+Tensor Cores
+------------
+
+The Tesla V100 contains 640 tensor cores (8 per SM) intended to enable
+faster training of large neural networks. Each tensor core performs a
+``D = AB + C`` operation on 4x4 matrices. A and B are FP16 matrices,
+while C and D can be either FP16 or FP32:
+
+.. image:: /images/nv_tensor_core_1.png
+   :width: 85.0%
+   :align: center
+
+Each of the 16 elements that result from the AB matrix multiplication
+come from 4 floating-point fused-multiply-add (FMA) operations
+(basically a dot product between a row of A and a column of B). Each
+FP16 multiply yields a full-precision product which is accumulated in a
+FP32 result:
+
+.. image:: /images/nv_tc_1.png
+   :width: 85.0%
+   :align: center
+
+Each tensor core performs 64 of these FMA operations per clock. The 4x4
+matrix operations outlined here can be combined to perform matrix
+operations on larger (and higher dimensional) matrices.
+
+Using the Tensor Cores on Summit
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+The NVIDIA Tesla V100 GPUs in Summit are capable of over 7TF/s of
+double-precision and 15 TF/s of single-precision floating point performance.
+Additionally, the V100 is capable of over 120 TF/s of half-precision floating
+point performance when using its Tensor Core feature. The Tensor Cores are
+purpose-built accelerators for half-precision matrix multiplication operations.
+While they were designed especially to accelerate machine learning workflows,
+they are exposed through several other APIs that are useful to other HPC
+applications. This section provides information for using the V100 Tensor
+Cores.
+
+The V100 Tensor Cores perform a warp-synchronous multiply and accumulate of
+16-bit matrices in the form of D = A * B + C. The operands of this matrix
+multiplication are 16-bit A and B matrices, while the C and D accumulation
+matrices may be 16 or 32-bit matrices with comparable performance for either
+precision.
+
+.. image:: /images/nv_tc_2.png
+   :width: 85.0%
+   :align: center
+
+Half precision floating point representation has a dramatically lower range of
+numbers than Double or Single precision. Half precision representation consists
+of 1 sign bit, a 5-bit exponent, and a 10-bit mantissa. This results in a
+dynamic range of 5.96e-8 to 65,504
+
+Tensor Core Programming Models
+""""""""""""""""""""""""""""""
+
+This section details a variety of high and low-level Tensor Core programming
+models. Which programming model is appropriate to a given application is highly
+situational, so this document will present multiple programming models to allow
+the reader to evaluate each for their merits within the needs of the
+application.
+
+cuBLAS Library
+______________
+
+cuBLAS is NVIDIA’s implementation of the Basic Linear Algebra Subroutines
+library for GPUs. It contains not only the Level 1, 2, and 3 BLAS routines, but
+several extensions to these routines that add important capabilities to the
+library, such as the ability to batch operations and work with varying
+precisions.
+
+The cuBLAS libraries provides access to the TensorCores using 3 different
+routines, depending on the application needs. The `cublasHgemm
+<https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-gemm>`_ routine
+performs a general matrix multiplication of half-precision matrices. The
+numerical operands to this routine must be of type half and math mode must be
+set to CUBLAS_TENSOR_OP_MATH to enable Tensor Core use. Additionally, if the
+`cublasSgemm
+<https://docs.nvidia.com/cuda/cublas/index.html#cublas-lt-t-gt-gemm>`_ routine
+will down-convert from single precision to half precision when the math mode is
+set to CUBLAS_TENSOR_OP_MATH, enabling simple conversion from SGEMM to HGEMM
+using Tensor Cores. For either of these two methods the `cublasSetMathMode
+<https://docs.nvidia.com/cuda/cublas/index.html#cublassetmathmode>`_ function
+must be used to change from CUBLAS_DEFAULT_MATH to CUBLAS_TENSOR_OP_MATH mode.
+
+cuBLAS provides a non-standard extension of GEMM with the `cublasGemmEx
+<https://docs.nvidia.com/cuda/cublas/index.html#cublas-GemmEx>`_ routine, which
+provides additional flexibility about the data types of the operands. In
+particular, the A, B, and C matrices can be of arbitrary and different types,
+with the types of each declared using the Atype, Btype, and Ctype parameters.
+The algo parameter works similar to the math mode above. If the math mode is
+set to CUBLAS_TESNOR_OP_MATH and the algo parameter is set to
+CUBLAS_GEMM_DEFAULT, then the Tensor Cores will be used. If algo is
+CUBLAS_GEMM_DEFAULT_TENSOR_OP or CUBLAS_GEMM_ALGO{0-15}_TENSOR_OP, then the
+Tensor Cores will be used regardless of the math setting. The table below
+outlines the rules stated in the past two paragraphs.
+
++----------------------------------------------------------+------------------------------------+--------------------------------------+
+|                                                          | ``mathMode = CUBLAS_DEFAULT_MATH`` | ``mathMode = CUBLAS_TENSOR_OP_MATH`` |
++==========================================================+====================================+======================================+
+| ``cublasHgemm, cublasSgemm, cublasGemmEx(algo=DEFAULT)`` | Disallowed                         | Allowed                              |
++----------------------------------------------------------+------------------------------------+--------------------------------------+
+| ``cublasGemmEx(algo=*_TENSOR_OP)``                       | Allowed                            | Allowed                              |
++----------------------------------------------------------+------------------------------------+--------------------------------------+
+
+
+When using any of these methods to access the Tensor Cores, the M, N, K, LDA,
+LDB, LDC, and A, B, and C pointers must all be aligned to 8 bytes due to the
+high bandwidth necessary to utilize the Tensor Cores effective.
+
+Many of the routines listed above are also available in batched form, see the
+`cuBLAS documentation <https://docs.nvidia.com/cuda/cublas/index.html>`_ for
+more information. Advanced users wishing to have increased control over the
+specifics of data layout, type, and underlying algorithms may wish to use the
+more advanced `cuBLAS-Lt interface
+<https://docs.nvidia.com/cuda/cublas/index.html#using-the-cublasLt-api>`_. This
+interface uses the same underlying GPU kernels, but provides developers with a
+higher degree of control.
+
+Iterative Refinement of Linear Solvers
+______________________________________
+
+Iterative Refinement is a technique for performing linear algebra solvers in a
+reduced precision, then iterating to improve the results and return them to
+full precision. This technique has been used for several years to use 32-bit
+math operations and achieve 64-bit results, which often results in a speed-up
+due to single precision math often have a 2X performance advantage on modern
+CPUs and many GPUs. NVIDIA and the University of Tennessee have been working to
+extend this technique to perform operations in half-precision and obtain higher
+precision results. One such place where this technique has been applied is in
+calculating an LU factorization of the linear system Ax = B. This operation is
+dominated by a matrix multiplication operation, which is illustrated in green
+in the image below. It is possible to perform the GEMM operations at a reduced
+precision, while leaving the panel and trailing matrices in a higher precision.
+This technique allows for the majority of the math operations to be done at the
+higher FP16 throughput. The matrix used in the GEMM is generally not square,
+which is often the best performing GEMM operation, but is referred to as rank-k
+and generally still very fast when using matrix multiplication libraries.
+
+.. image:: /images/nv_tc_3.png
+   :width: 85.0%
+   :align: center
+
+A summary of the algorithm used for calculating in mixed precision is in the
+following image.
+
+.. image:: /images/nv_tc_4.png
+   :width: 85.0%
+   :align: center
+
+We see in the graph below that it is possible to achieved a 3-4X performance
+improvement over the double-precision solver, while achieving the same level of
+accuracy. It has also been observed that the use of Tensor Cores makes the
+problem more likely to converge than strict half-precision GEMMs due to the
+ability to accumulate into 32-bit results.
+
+.. image:: /images/nv_tc_5.png
+   :width: 85.0%
+   :align: center
+
+NVIDIA will be shipping official support for IR solvers in their cuSOLVER
+library in the latter half of 2019. The image below provides estimated release
+dates, which are subject to change.
+
+.. image:: /images/nv_tc_6.png
+   :width: 85.0%
+   :align: center
+
+Automatic Mixed Precision (AMP) in Machine Learning Frameworks
+______________________________________________________________
+
+NVIDIA has a Training With Mixed Precision guide available for developers
+wishing to explicitly use mixed precision and Tensor Cores in their training of
+neural networks. This is a good place to start when investigating Tensor Cores
+for machine learning applications. Developers should specifically read the
+Optimizing For Tensor Cores section.
+
+NVIDIA has also integrated a technology called Automatic Mixed Precision (AMP)
+into several common frameworks, TensorFlow, PyTorch, and MXNet at time of
+writing. In most cases AMP can be enabled via a small code change or via
+setting and environment variable. AMP does not strictly replace all matrix
+multiplication operations with half precision, but uses graph optimization
+techniques to determine whether a given layer is best run in full or half
+precision.
+
+Examples are provided for using AMP, but the following sections summarize the
+usage in the three supported frameworks.
+
+TensorFlow
+..........
+
+With TensorFlow AMP can be enabled using one of the following techniques.
+
+::
+
+  os.environ['TF_ENABLE_AUTO_MIXED_PRECISION'] = '1'
+
+OR
+
+::
+
+  export TF_ENABLE_AUTO_MIXED_PRECISION=1
+
+Explicit optimizer wrapper available in NVIDIA Container 19.07+, TF 1.14+, TF
+2.0:
+
+::
+
+  opt = tf.train.experimental.enable_mixed_precision_graph_rewrite(opt)
+
+
+PyTorch
+.......
+
+Adding the following to a PyTorch model will enable AMP:
+
+::
+
+  model, optimizer = amp.initialize(model, optimizer, opt_level="O1")
+  with amp.scale_loss(loss, optimizer) as scaled_loss:
+    scaled_loss.backward()
+
+MXNet
+.....
+
+The code below will enable AMP for MXNet:
+
+::
+
+  amp.init()
+  amp.init_trainer(trainer)
+  with amp.scale_loss(loss, trainer) as scaled_loss:
+    autograd.backward(scaled_loss)
+
+
+WMMA
+____
+
+The Warp Matrix Multiply and Accumulate (WMMA) API was introduced in CUDA 9
+explicitly for programming the Tesla V100 Tensor Cores. This is a low-level API
+that supports loading matrix data into fragments within the threads of a warp,
+applying a Tensor Core multiplication on that data, and then restoring it to
+the main GPU memory. This API is called within CUDA kernels and all WMMA
+operations are warp-synchronous, meaning the threads in a warp will leave the
+operation synchronously. Examples are available for using the WMMA instructions
+in C++ and CUDA Fortran. The image below demonstrates the general pattern for
+WMMA usage.
+
+.. image:: /images/nv_tc_7.png
+   :width: 85.0%
+   :align: center
+
+The example above performs a 16-bit accumulate operation, but 32-bit is also
+supported. Please see the provided samples and the `WMMA documentation
+<https://docs.nvidia.com/cuda/cuda-c-programming-guide/index.html#wmma>`_ for
+more details.
+
+CUDA 10 introduced a lower-level alternative to WMMA with the mma.sync()
+instruction. This is a very low-level instruction that requires the programmer
+handle the data movement provided by WMMA explicitly, but is capable of higher
+performance. Details of `mma.sync
+<https://docs.nvidia.com/cuda/parallel-thread-execution/index.html#warp-level-matrix-instructions-wmma-mma>`_
+can be found in the PTX documentation and examples for using this feature via
+CUTLASS cane be found in the second half of this `GTC presentation
+<https://on-demand-gtc.gputechconf.com/gtcnew/sessionview.php?sessionName=s9593-cutensor%3a+high-performance+tensor+operations+in+cuda>`_.
+
+CUTLASS
+_______
+
+`CUTLASS <https://github.com/nvidia/cutlass/>`_ is an open-source library
+provided by NVIDIA for building matrix multiplication operations using C++
+templates. The goal is to provide performance that is nearly as good as the
+hand-tuned cuBLAS library, but in a more expressive, composible manner.
+
+The CUTLASS library provides a variety of primitives that are optimized for
+proper data layout and movement to achieve the maximum possible performance of
+a matrix multiplation on an NVIDIA GPU. These include iterators for blocking,
+loading, and storing matrix tiles, plus optimized classes for transforming the
+data and performing the actual multiplication. CUTLASS provides `extensive
+documentation <https://github.com/NVIDIA/cutlass/blob/master/CUTLASS.md>`_ of
+these features and examples have been provided. Interested developers are also
+encouraged to watch the `CUTLASS introduction video
+<https://on-demand-gtc.gputechconf.com/gtcnew/sessionview.php?sessionName=s8854-cutlass%3a+software+primitives+for+dense+linear+algebra+at+all+levels+and+scales+within+cuda>`_
+from GTC2018.
+
+Measuring Tensor Core Utilization
+"""""""""""""""""""""""""""""""""
+
+When attempting to use Tensor Cores it is useful to measure and confirm that
+the Tensor Cores are being used within your code. For implicit use via a
+library like cuBLAS, the Tensor Cores will only be used above a certain
+threshold, so Tensor Core use should not be assumed. The NVIDIA Tools provide a
+performance metric to measure Tensor Core utilization on a scale from 0 (Idle)
+to 10 (Max) utilization.
+
+When using NVIDIA’s nvprof profiler, one should add the `-m
+tensor_precision_fu_utilization` option to measure Tensor Core utilization.
+Below is the output from measuring this metric on one of the example programs.
+
+::
+
+  $ nvprof -m tensor_precision_fu_utilization ./simpleCUBLAS
+  ==43727== NVPROF is profiling process 43727, command: ./simpleCUBLAS
+  GPU Device 0: "Tesla V100-SXM2-16GB" with compute capability 7.0
+
+  simpleCUBLAS test running..
+  simpleCUBLAS test passed.
+  ==43727== Profiling application: ./simpleCUBLAS
+  ==43727== Profiling result:
+  ==43727== Metric result:
+  Invocations                               Metric Name                           Metric Description         Min         Max         Avg
+  Device "Tesla V100-SXM2-16GB (0)"
+      Kernel: volta_h884gemm_128x64_ldg8_nn
+            1           tensor_precision_fu_utilization   Tensor-Precision Function Unit Utilization     Low (3)     Low (3)     Low (3)
+
+
+NVIDIA’s Nsight Compute may also be used to measure tensor core utilization via
+the sm__pipe_tensor_cycles_active.avg.pct_of_peak_sustained_active metric, as
+follows:
+
+::
+
+  $ nv-nsight-cu-cli --metrics sm__pipe_tensor_cycles_active.avg.pct_of_peak_sustained_active ./cudaTensorCoreGemm
+
+  [  compute_gemm, 2019-Aug-08 12:48:39, Context 1, Stream 7
+        Section: Command line profiler metrics
+        ---------------------------------------------------------------------- 
+        sm__pipe_tensor_cycles_active.avg.pct_of_peak_sustained_active                    %                       43.44
+        ----------------------------------------------------------------------
+
+
+When to Try Tensor Cores
+""""""""""""""""""""""""
+
+Tensor Cores provide the potential for an enormous performance boost over
+full-precision operations, but when their use is appropriate is highly
+application and even problem independent. Iterative Refinement techniques can
+suffer from slow or possible a complete lack of convergence if the condition
+number of the matrix is very large. By using Tensor Cores, which support 32-bit
+accumulation, rather than strict 16-bit math operations, iterative refinement
+becomes a viable option in a much larger number of cases, so it should be
+attempted when an application is already using a supported solver.
+
+Even if iterative techniques are not available for an application, direct use
+of Tensor Cores may be beneficial if at least the A and B matrices can be
+constructed from the input data without significant loss of precision. Since
+the C and D matrices may be 32-bit, the output may have a higher degree of
+precision than the input. It may be possible to try these operations
+automatically by setting the math mode in cuBLAS, as detailed above, to
+determine whether the loss of precision is an acceptable trade-off for
+increased performance in a given application. If it is, the cublasGemmEx API
+allows the programmer to control when the conversion to 16-bit occurs, which
+may result in higher throughput than allowing the cuBLAS library to do the
+conversion at call time.
+
+Some non-traditional uses of Tensor Cores can come from places where integers
+that fall within the FP16 range are used in an application. For instance, in
+“Attacking the Opioid Epidemic: Determining the Epistatic and Pleiotropic
+Genetic Architectures for Chronic Pain and Opioid Addiction,” a 2018 Gordon
+Bell Prize-winning paper, the authors used Tensor Cores in place of small
+integers, allowing them very high performance over performing the same
+calculation in integer space. This technique is certainly not applicable to all
+applications, but does show that Tensor Cores may be used in algorithms that
+might not have been represented by a floating point matrix multiplication
+otherwise.
+
+Lastly, when performing the training step of a deep learning application it is
+often beneficial to do at least some of the layer calculations in reduced
+precision. The AMP technique described above can be tried with little to know
+code changes, making it highly advisable to attempt in any machine learning
+application.
+
+Tensor Core Examples and Other Materials
+""""""""""""""""""""""""""""""""""""""""
+
+NVIDIA has provided several example codes for using Tensor Cores from a variety
+of the APIs listed above. These examples can be found on `GitHub
+<https://github.com/olcf/NVIDIA-tensor-core-examples>`_.
+
+NVIDIA Tensor Core Workshop (August 2018): `slides
+<https://www.olcf.ornl.gov/wp-content/uploads/2019/11/ORNL_Tensor_Core_Training_Aug2019.pdf>`_,
+recording (coming soon)
+
+
+Tesla V100 Specifications
+-------------------------
+
++----------------------------------------------------+----------------------------+
+| Compute Capability                                 | 7.0                        |
++----------------------------------------------------+----------------------------+
+| Peak double precision floating point performance   | 7.8 TFLOP/s                |
++----------------------------------------------------+----------------------------+
+| Peak single precision floating point performance   | 15.7 TFLOP/s               |
++----------------------------------------------------+----------------------------+
+| Single precision CUDA cores                        | 5120                       |
++----------------------------------------------------+----------------------------+
+| Double precision CUDA cores                        | 2560                       |
++----------------------------------------------------+----------------------------+
+| Tensor cores                                       | 640                        |
++----------------------------------------------------+----------------------------+
+| Clock frequency                                    | 1530 MHz                   |
++----------------------------------------------------+----------------------------+
+| Memory Bandwidth                                   | 900 GB/s                   |
++----------------------------------------------------+----------------------------+
+| Memory size (HBM2)                                 | 16 or 32 GB                |
++----------------------------------------------------+----------------------------+
+| L2 cache                                           | 6 MB                       |
++----------------------------------------------------+----------------------------+
+| Shared memory size / SM                            | Configurable up to 96 KB   |
++----------------------------------------------------+----------------------------+
+| Constant memory                                    | 64 KB                      |
++----------------------------------------------------+----------------------------+
+| Register File Size                                 | 256 KB (per SM)            |
++----------------------------------------------------+----------------------------+
+| 32-bit Registers                                   | 65536 (per SM)             |
++----------------------------------------------------+----------------------------+
+| Max registers per thread                           | 255                        |
++----------------------------------------------------+----------------------------+
+| Number of multiprocessors (SMs)                    | 80                         |
++----------------------------------------------------+----------------------------+
+| Warp size                                          | 32 threads                 |
++----------------------------------------------------+----------------------------+
+| Maximum resident warps per SM                      | 64                         |
++----------------------------------------------------+----------------------------+
+| Maximum resident blocks per SM                     | 32                         |
++----------------------------------------------------+----------------------------+
+| Maximum resident threads per SM                    | 2048                       |
++----------------------------------------------------+----------------------------+
+| Maximum threads per block                          | 1024                       |
++----------------------------------------------------+----------------------------+
+| Maximum block dimensions                           | 1024, 1024, 64             |
++----------------------------------------------------+----------------------------+
+| Maximum grid dimensions                            | 2147483647, 65535, 65535   |
++----------------------------------------------------+----------------------------+
+| Maximum number of MPS clients                      | 48                         |
++----------------------------------------------------+----------------------------+
+
+ 
+
+Further Reading
+---------------
+
+For more information on the NVIDIA Volta architecture, please visit the
+following (outside) links.
+
+* `NVIDIA Volta Architecture White Paper <http://images.nvidia.com/content/volta-architecture/pdf/volta-architecture-whitepaper.pdf>`_
+* `NVIDIA PARALLEL FORALL blog article <https://devblogs.nvidia.com/parallelforall/inside-volta/>`_
+
+
+.. _burst-buffer:
+
+Burst Buffer
+=============
+
+NVMe (XFS)
+----------
+
+Each compute node on Summit has a 1.6TB \ **N**\ on-\ **V**\ olatile **Me**\
+mory (NVMe) storage device (high-memory nodes have a 6.4TB NVMe storage device), colloquially known as a "Burst Buffer" with
+theoretical performance peak of 2.1 GB/s for writing and 5.5 GB/s for reading.
+100GB of each NVMe is reserved for NFS cache to help speed access to common
+libraries. When calculating maximum usable storage size, this cache and
+formatting overhead should be considered; We recommend a maximum storage of
+1.4TB (6TB for high-memory nodes). The NVMes could be used to reduce the time that applications wait for
+I/O. Using an SSD drive per compute node, the burst buffer will be used to
+transfer data to or from the drive before the application reads a file or
+after it writes a file.  The result will be that the application benefits from
+native SSD performance for a portion of its I/O requests. Users are not
+required to use the NVMes.  Data can also be written directly to the parallel
+filesystem.
+
+.. figure:: /images/nvme_arch.jpg
+   :align: center
+
+   The NVMes on Summit are local to each node.
+
+Current NVMe Usage
+-------------------
+
+Tools for using the burst buffers are still under development.  Currently, the
+user will have access to a writeable directory on each node's NVMe and then
+explicitly move data to and from the NVMes with posix commands during a job.
+This mode of usage only supports writing file-per-process or file-per-node.
+It does not support automatic "n to 1" file writing, writing from multiple nodes
+to a single file.  After a job completes the NVMes are trimmed, a process
+that irreversibly deletes data from the devices, so all desired data from the
+NVMes will need to be copied back to the parallel filesystem before the job
+ends. This largely manual mode of usage will not be the recommended way to use
+the burst buffer for most applications because tools are actively being
+developed to automate and improve the NVMe transfer and data management process.
+Here are the basic steps for using the BurstBuffers in their current limited
+mode of usage:
+
+
+#. Modify your application to write to /mnt/bb/$USER, a directory that will be
+   created on each NVMe.
+
+#. Modify either your application or your job submission script to copy the
+   desired data from /mnt/bb/$USER back to the parallel filesystem before the
+   job ends.
+
+#. Modify your job submission script to include the ``-alloc_flags NVME``  bsub
+   option. Then on each reserved Burst Buffer node will be available a directory
+   called /mnt/bb/$USER.
+
+#. Submit your bash script or run the application.
+
+#. Assemble the resulting data as needed.
+
+Interactive Jobs Using the NVMe
+--------------------------------
+
+The NVMe can be setup for test usage within an interactive job as follows:
+
+.. code::
+
+    bsub -W 30 -nnodes 1 -alloc_flags "NVME" -P project123 -Is bash
+
+The ``-alloc_flags NVME`` option will create a directory called /mnt/bb/$USER on
+each requested node's NVMe. The ``/mnt/bb/$USER`` directories will be writeable
+and readable until the interactive job ends. Outside of a job ``/mnt/bb/`` will
+be empty and you will not be able to write to it.
+
+NVMe Usage Example
+-------------------
+
+The following example illustrates how to use the burst buffers (NVMes) by
+default on Summit. This example uses a submission script, check_nvme.lsf. It is
+assumed that the files are saved in the user's GPFS scratch area,
+/gpfs/alpine/scratch/$USER/projid, and that the user is operating from there as
+well. Do not forget that for all the commands on NVMe, it is required to use
+jsrun. This will submit a job to run on one node.
+
+**Job submssion script: check_nvme.lsf.** 
+
+.. code::
+
+   #!/bin/bash
+   #BSUB -P project123
+   #BSUB -J name_test
+   #BSUB -o nvme_test.o%J
+   #BSUB -W 2
+   #BSUB -nnodes 1
+   #BSUB -alloc_flags NVME
+
+   #Declare your project in the variable
+   projid=xxxxx
+   cd /gpfs/alpine/scratch/$USER/$projid
+
+   #Save the hostname of the compute node in a file
+   jsrun -n 1 echo $HOSTNAME > test_file
+
+   #Check what files are saved on the NVMe, always use jsrun to access the NVMe devices
+   jsrun -n 1 ls -l /mnt/bb/$USER/
+
+   #Copy the test_file in your NVMe
+   jsrun -n 1 cp test_file /mnt/bb/$USER/
+
+   #Delete the test_file from your local space
+   rm test_file
+
+   #Check again what the NVMe folder contains
+   jsrun -n 1 ls -l /mnt/bb/$USER/
+
+   #Output of the test_file contents
+   jsrun -n 1 cat /mnt/bb/$USER/test_file
+
+   #Copy the file from the NVMe to your local space
+   jsrun -n 1 cp /mnt/bb/$USER/test_file .
+
+   #Check the file locally
+   ls -l test_file
+
+To run this example: ``bsub ./check_nvme.lsf``.   We could include all the
+commands in a script and call this file as a jsrun argument in an interactive
+job, in order to avoid changing numbers of processes for all the jsrun
+calls. You can see in the table below an example of the differences in a
+submission script for executing an application on GPFS and NVMe. In the example,
+a binary ``./btio`` reads input from an input file and generates output files.
+In this particular case we copy the binary and the input file onto the NVMe, but
+this depends on the application as it is not always necessary, we can execute
+the binary on the GPFS and write/read the data from NVMe if it is supported by
+the application.
+
+.. role:: raw-html(raw)
+    :format: html
+
++----------------------------------------+------------------------------------------------+
+| *Using GPFS*          		 | *Using NVMe*         			  |
++----------------------------------------+------------------------------------------------+
+|               	``#!/bin/bash``  | ``#!/bin/bash`` 	     			  |
++----------------------------------------+------------------------------------------------+
+| 	 	       ``#BSUB -P xxx``  | ``#BSUB -P xxx``  		   	          |
++----------------------------------------+------------------------------------------------+
+|	  	  ``#BSUB -J NAS-BTIO``  | ``#BSUB -J NAS-BTIO``  			  |
++----------------------------------------+--------------+---------------------------------+
+|   	       ``#BSUB -o nasbtio.o%J``  | ``#BSUB -o nasbtio.o%J`` 	                  |
++----------------------------------------+---------------+--------------------------------+
+|              ``#BSUB -e nasbtio.e%J``  | ``#BSUB -e nasbtio.e%J``   			  |
++----------------------------------------+------------------------------------------------+
+|			``#BSUB -W 10``  | ``#BSUB -W 10``    		 	          |
++----------------------------------------+------------------------------------------------+
+|	     ``#BSUB -nnodes 1``         | ``#BSUB -nnodes 1``  	 		  |
++----------------------------------------+------------------------------------------------+
+| 		    			 | ``#BSUB -alloc_flags nvme`` 			  |
+|					 +------------------------------------------------+
+| 	            			 | ``export BBPATH=/mnt/bb/$USER/``		  |
+|					 +------------------------------------------------+
+| 		    			 | ``jsrun -n 1 cp btio ${BBPATH}``		  |
+|					 +------------------------------------------------+
+| 		    			 | ``jsrun -n 1 cp input* ${BBPATH}``		  |
+|					 +------------------------------------------------+
+| ``jsrun -n 1 -a 16 -c 16 -r 1 ./btio`` | ``jsrun -n 1 -a 16 -c 16 -r 1 ${BBPATH}/btio`` |
+|					 +------------------------------------------------+
+| ``ls -l``		`		 | ``jsrun -n 1 ls -l ${BBPATH}/``		  |
+|					 +------------------------------------------------+
+|					 | ``jsrun -n 1 cp ${BBPATH}/* .``		  |
++----------------------------------------+------------------------------------------------+
+
+When a user occupies more than one compute node, then they are using more NVMes
+and the I/O can scale linearly. For example in the following plot you can observe
+the scalability of the IOR benchmark on 2048 compute nodes on Summit where the
+write performance achieves 4TB/s and the read 11.3 TB/s
+
+
+.. image:: /images/nvme_ior_summit.png
+   :align: center
+
+Remember that by default NVMe support one file per MPI process up to one file
+per compute node. If users desire a single file as output from data staged on
+the NVMe they will need to construct it.  Tools to save automatically checkpoint
+files from NVMe to GPFS as also methods that allow automatic n to 1 file writing
+with NVMe staging are under development.   Tutorials about NVME:   Burst Buffer
+on Summit (`slides
+<https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_BB_markomanolis.pdf>`__,
+`video <https://vimeo.com/306890779>`__) Summit Burst Buffer Libraries (`slides
+<https://www.olcf.ornl.gov/wp-content/uploads/2018/12/summit_workshop_BB_zimmer.pdf>`__,
+`video <https://vimeo.com/306891012>`__). 
+
+.. _spectral-library:
+
+Spectral Library
+----------------
+
+Spectral is a portable and transparent middleware library to enable use of the
+node-local burst buffers for accelerated application output on Summit. It is
+used to transfer files from node-local NVMe back to the parallel GPFS file
+system without the need of the user to interact during the job execution.
+Spectral runs on the isolated core of each reserved node, so it does not occupy
+resources and based on some parameters the user could define which folder to be
+copied to the GPFS. In order to use Spectral, the user has to do the following
+steps in the submission script:
+
+#. Request Spectral resources instead of NVMe
+#. Declare the path where the files will be saved in the node-local NVMe
+   (PERSIST_DIR)
+#. Declare the path on GPFS where the files will be copied (PFS_DIR)
+#. Execute the script spectral_wait.py when the application is finished in order
+   to copy the files from NVMe to GPFS
+
+The following table shows the differences of executing an application on GPFS,
+NVMe, and NVMe with Spectral. This example is using one compute node. We copy
+the executable and input file for the NVMe cases but this is not always
+necessary. Depending on the application, you could execute the binary from the
+GPFS and save the output files on NVMe. Adjust your parameters to copy, if
+necessary, the executable and input files onto all the NVMe devices.
+
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| *Using GPFS* 			         | *Using NVMe*                                   | *Using NVME with Spectral library*             |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| ``#!/bin/bash``		         | ``#!/bin/bash``                                | ``#!/bin/bash``                                |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| ``#BSUB -P xxx``		         | ``#BSUB -P xxx``                               | ``#BSUB -P xxx``                               |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| ``#BSUB -J NAS-BTIO``		         | ``#BSUB -J NAS-BTIO``                          | ``#BSUB -J NAS-BTIO``                          |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| ``#BSUB -o nasbtio.o%J``	         | ``#BSUB -o nasbtio.o%J``                       | ``#BSUB -o nasbtio.o%J``                       |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| ``#BSUB -e nasbtio.e%J``	         | ``#BSUB -e nasbtio.e%J``                       | ``#BSUB -e nasbtio.e%J``                       |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| ``#BSUB -W 10``		         | ``#BSUB -W 10``                                | ``#BSUB -W 10``                                |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| ``#BSUB -nnodes 1``		         | ``#BSUB -nnodes 1``                            | ``#BSUB -nnodes 1``                            |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| 				         | ``#BSUB -alloc_flags nvme``                    | ``#BSUB -alloc_flags spectral``                |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| 				         |                                                | ``module load spectral``                       |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| 				         | ``export BBPATH=/mnt/bb/$USER``                | ``export BBPATH=/mnt/bb/$USER``                |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| 				         |                                                | ``export PERSIST_DIR=${BBPATH}``               |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| 				         |                                                | ``export PFS_DIR=$PWD/spect/``                 |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| 				         | ``jsrun -n 1 cp btio ${BBPATH}``               | ``jsrun -n 1 cp btio ${BBPATH}``               |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| 				         | ``jsrun -n 1 cp input* ${BBPATH}``             | ``jsrun -n 1 cp input* ${BBPATH}``             |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| ``jsrun -n 1 -a 16 -c 16 -r 1 ./btio`` | ``jsrun -n 1 -a 16 -c 16 -r 1 ${BBPATH}/btio`` | ``jsrun -n 1 -a 16 -c 16 -r 1 ${BBPATH}/btio`` |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| ``ls -l``			         | ``jsrun -n 1 ls -l ${BBPATH}/``	          | ``jsrun -n 1 ls -l ${BBPATH}/``	           |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+| 				         | ``jsrun -n 1 cp ${BBPATH}/* .``                | ``spectral_wait.py``                           |
++----------------------------------------+------------------------------------------------+------------------------------------------------+
+
+
+When the Spectral library is not used, any output data produced has to be copied
+back from NVMe.  You can observe that with the Spectral library there is no reason
+to explicitly ask for the data to be copied to GPFS as it is done automatically
+through the spectral_wait.py script. Also a log file called spectral.log will be
+created with information on the files that were copied.
+
+.. _known-issues:
+
+Known Issues
+============
+
+Last Updated: 07 February 2023
+
+Open Issues
+-----------
+
+HIP code cannot be built using CMake using hip::host/device or HIP language support
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Using the ``hip-cuda/5.1.0`` module on Summit, applications cannot build using a ``CMakeLists.txt`` that requires HIP language support or references the ``hip::host`` and ``hip::device`` identifiers. There is no known workaround for this issue. Applications wishing to compile HIP code with CMake need to avoid using HIP language support or ``hip::host`` and ``hip::device`` identifiers.
+
+Unsupported CUDA versions do not work with GPU-aware MPI
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Although there are newer CUDA modules on Summit, ``cuda/11.0.3`` is the latest version that is officially supported by the version of IBM's software stack installed on Summit. When loading the newer CUDA modules, a message is printed to the screen stating that the module is for “testing purposes only”. These newer unsupported CUDA versions might work with some users’ applications, but importantly, they are known **not** to work with GPU-aware MPI.
+
+HIP does not currently work with GPU-aware MPI
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Using the ``hip-cuda/5.1.0`` module on Summit requires CUDA v11.4.0 or later. However, only CUDA v11.0.3 and earlier currently support GPU-aware MPI, so GPU-aware MPI is currently not available when using HIP on Summit.
+
+MPS does not currently work with codes compiled with post 11.0.3 CUDA
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Any codes compiled with post 11.0.3 CUDA (``cuda/11.0.3``) will not work with MPS enabled (``-alloc_flags "gpumps"``) on Summit. The code will hang indefinitely. CUDA v11.0.3 is the latest version that is officially supported by IBM's software stack installed on Summit. We are continuing to look into this issue.
+
+System not sourcing ``.bashrc``, ``.profile``, etc. files as expected
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Some users have noticed that their login shells, batch jobs, etc. are not sourcing shell run control files as expected. This is related to the way bash is initialized. The initialization process is discussed in the INVOCATION section of the bash manpage, but is summarized here.
+
+Bash sources different files based on two attributes of the shell: whether or not it's a login shell, and whether or not it's an interactive shell. These attributes are not mutually exclusive (so a shell can be "interactive login", "interactive non-login", etc.):
+
+#. If a shell is an interactive login shell (i.e. an ssh to the system) or a non-interactive shell started with the ``--login`` option (say, a batch script with ``#!/bin/bash --login`` as the first line), it will source ``/etc/profile`` and will then search your home directory for ``~/.bash_profile``, ``~/.bash_login``, and ``~/.profile``. It will source the first of those that it finds (once it sources one, it stops looking for the others).
+#. If a shell is an interactive, non-login shell (say, if you run 'bash' in your login session to start a subshell), it will source ``~/.bashrc``
+#. If a shell is a non-interactive, non-login shell, it will source whatever file is defined by the ``$BASH_ENV`` variable in the shell from which it was invoked. 
+
+In any case, if the files listed above that should be sourced in a particular situation do not exist, it is not an error. 
+
+On Summit and Andes, batch-interactive jobs using bash (i.e. those submitted with ``bsub -Is`` or ``salloc``) run as interactive, non-login shells (and therefore source ``~/.bashrc``, if it exists). Regular batch jobs using bash on those systems are non-interactive, non-login shells and source the file defined by the variable ``$BASH_ENV`` in the shell from which you submitted the job. This variable is not set by default, so this means that none of these files will be sourced for a regular batch job unless you explicitly set that variable.
+
+Some systems are configured to have additional files in ``/etc`` sourced, and sometimes the files in ``/etc`` look for and source files in your home directory such as ``~/.bashrc``, so the behavior on any given system may seem to deviate a bit from the information above (which is from the bash manpage). This can explain why jobs (or other shells) on other systems you've used have sourced your ``.bashrc`` file on login.
+
+Improper permissions on ``~/.ssh/config`` cause job state flip-flop/jobs ending in suspended state
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Improper permissions on your SSH configuration file (``~/.ssh/config``) will cause jobs to alternate between pending & running states until the job ultimately ends up in a PSUSP state.
+
+LSF uses SSH to communicate with nodes allocated to your job, and in this case the improper permissions (i.e. write permission for anyone other than the user) cause SSH to fail, which in turn causes the job launch to fail. Note that SSH only checks the permissions of the configuration file itself. Thus, even if the ``~/.ssh/`` directory itself grants no group or other permissions, SSH will fail due to permissions on the configuration file.
+
+To fix this, use a more secure permission setting on the configuration file. An appropriate setting would be read and write permission for the user and no other permissions. You can set this with the command ``chmod 600 ~/.ssh/config``.
+
+Setting ``TMPDIR`` causes JSM (``jsrun``) errors / job state flip-flop
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Setting the ``TMPDIR`` environment variable causes jobs to fail with JSM
+(``jsrun``) errors and can also cause jobs to bounce back and forth between
+eligible and running states until a retry limit has been reached and the job is
+placed in a blocked state (NOTE: This "bouncing" of job state can be caused for
+multiple reasons. Please see the known issue `Jobs suspended due to retry limit
+/ Queued job flip-flops between queued/running states`_ if you are not setting
+``TMPDIR``). A bug has been filed with IBM to address this issue.
+
+When ``TMPDIR`` is set within a running job (i.e., in an interactive session or
+within a batch script), any attempt to call ``jsrun`` will lead to a job
+failure with the following error message:
+
+::
+
+	Error: Remote JSM server is not responding on host batch503-25-2020 15:29:45:920 90012 main: Error initializing RM connection. Exiting.
+
+When ``TMPDIR`` is set before submitting a job (i.e., in the shell/environment
+where a job is submitted from), the job will bounce back and forth between a
+running and eligible state until its retry limit has been reached and the job
+will end up in a blocked state. This is true for both interactive jobs and jobs
+submitted with a batch script, but interactive jobs will hang without dropping
+you into your interactive shell. In both cases, JSM log files (e.g.,
+``jsm-lsf-wait.username.1004985.log``) will be created in the location set for
+``TMPDIR`` containing the same error message as shown above. 
+
+Segfault when running executables on login nodes
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Executing a parallel binary on the login node or a batch node without using the
+job step launcher ``jsrun`` will result in a segfault. 
+
+This also can be encountered when importing parallel Python libraries like
+``mpi4py`` and ``h5py`` directly on these nodes.
+
+The issue has been reported to IBM. The current workaround is to run the binary
+inside an interactive or batch job via ``jsrun``.
+
+Nsight Compute cannot be used with MPI programs
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When profiling an MPI application using NVIDIA Nsight Compute, like the following,
+you may see an error message in Spectrum MPI that aborts the program:
+
+::
+
+   jsrun -n 1 -a 1 -g 1 nv-nsight-cu-cli ./a.out
+   
+   Error: common_pami.c:1049 - ompi_common_pami_init() Unable to create PAMI client (rc=1)
+   --------------------------------------------------------------------------
+   No components were able to be opened in the pml framework.
+
+   This typically means that either no components of this type were
+   installed, or none of the installed components can be loaded.
+   Sometimes this means that shared libraries required by these
+   components are unable to be found/loaded.
+
+   Host:      <host>
+   Framework: pml
+   --------------------------------------------------------------------------
+   PML pami cannot be selected
+
+This is due to an incompatibility in the 2019.x versions of Nsight Compute with
+Spectrum MPI. As a workaround, you can disable CUDA hooks in Spectrum MPI using
+
+::
+   
+   jsrun -n 1 -a 1 -g 1 --smpiargs="-disable_gpu_hooks" nv-nsight-cu-cli ./a.out
+
+Unfortunately, this is incompatible with using CUDA-aware MPI in your application.
+
+This will be resolved in a future release of CUDA.
+
+CUDA hook error when program uses CUDA without first calling MPI_Init()
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Serial applications, that are not MPI enabled, often face the following
+issue when compiled with Spectrum MPI's wrappers and run with jsrun:
+
+::
+
+   CUDA Hook Library: Failed to find symbol mem_find_dreg_entries, ./a.out: undefined symbol: __PAMI_Invalidate_region
+
+The same issue can occur if CUDA API calls that interact with the GPU
+(e.g. allocating memory) are called before MPI_Init() in an MPI enabled
+application. Depending on context, this error can either be harmless or
+it can be fatal.
+
+The reason this occurs is that the PAMI messaging backend, used by Spectrum
+MPI by default, has a "CUDA hook" that records GPU memory allocations.
+This record is used later during CUDA-aware MPI calls to efficiently detect
+whether a given message is sent from the CPU or the GPU. This is done by
+design in the IBM implementation and is unlikely to be changed.
+
+There are two main ways to work around this problem. If CUDA-aware MPI is
+not a relevant factor for your work (which is naturally true for serial
+applications) then you can simply disable the CUDA hook with:
+
+::
+
+   --smpiargs="-disable_gpu_hooks"
+
+as an argument to jsrun. Note that this is not compatible with the ``-gpu``
+argument to ``--smpiargs``, since that is what enables CUDA-aware MPI and
+the CUDA-aware MPI functionality depends on the CUDA hook.
+
+If you do need CUDA-aware MPI functionality, then the only known working
+solution to this problem is to refactor your code so that no CUDA calls
+occur before MPI_Init(). (This includes any libraries or programming models
+such as OpenACC or OpenMP that would use CUDA behind the scenes.) While it
+is not explicitly codified in the standard, it is worth noting that the major
+MPI implementations all recommend doing as little as possible before MPI_Init(),
+and this recommendation is consistent with that.
+
+Spindle is not currently supported
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Users should not use ``USE_SPINDLE=1`` or ``LOAD_SPINDLE=1`` in their
+``~/.jsm.conf`` file at this time. A bug has been filed with IBM to
+address this issue.
+
+Spectrum MPI tunings needed for maximum bandwidth
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, Spectrum MPI is configured for minimum latency. If your
+application needs maximum bandwidth, the following settings are
+recommended:
+
+::
+
+    $ export PAMI_ENABLE_STRIPING=1
+    $ export PAMI_IBV_ADAPTER_AFFINITY=1
+    $ export PAMI_IBV_DEVICE_NAME="mlx5_0:1,mlx5_3:1"
+    $ export PAMI_IBV_DEVICE_NAME_1="mlx5_3:1,mlx5_0:1"
+
+Debugging slow application startup or slow performance
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In order for debugging and profiling tools to work, you need to unload
+Darshan
+
+::
+
+    $ module unload darshan-runtime
+
+Spectrum MPI provides a tracing library that can be helpful to gather
+more detail information about the MPI communication of your job. To
+gather MPI tracing data, you can set
+``export OMPI_LD_PRELOAD_POSTPEND=$OLCF_SPECTRUM_MPI_ROOT/lib/libmpitrace.so``
+in your environment. This will generate profile files with timings for
+the individual processes of your job.
+
+In addition, to debug slow startup JSM provides the option to create a
+progress file. The file will show information that can be helpful to
+pinpoint if a specific node is hanging or slowing down the job step
+launch. To enable it, you can use: ``jsrun --progress
+./my_progress_file_output.txt``.
+
+-a flag ignored when using a jsrun resource set file with -U
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using file-based specification of resource sets with ``jsrun -U``,
+the ``-a`` flag (number of tasks per resource set) is ignored. This has
+been reported to IBM and they are investigating. It is generally
+recommended to use jsrun explicit resource files (ERF) with
+``--erf_input`` and ``--erf_output`` instead of ``-U``.
+
+
+Jobs suspended due to retry limit / Queued job flip-flops between queued/running states
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some users have reported seeing their jobs transition from the normal
+queued state, into a running state, and then back again to queued.
+Sometimes this can happen multiple times. Eventually, internal limits in
+the LSF scheduler will be reached, at which point the job will no longer
+be eligible for running. The ``bhist`` command can be used to see if a job
+is cycling between running and eligible states. The pending reason given
+by ``bhist`` can also be useful to debug. This can happen due to
+modifications that the user has made to their environment on the system,
+incorrect SSH key setup, attempting to load unavailable/broken modules.
+or system problems with individual nodes. When jobs are observed to
+flip-flop between running and queued, and/or become ineligible without
+explanation, then deeper investigation is required and the user should
+write to help@olcf.ornl.gov.
+
+jsrun explicit resource file (ERF) output format error
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+jsrun's option to create an explicit resource file (``--erf_output``) will
+incorrectly create a file with one line per rank. When reading the file
+in with (``--erf_input``) you will see warnings for overlapping resource
+sets. This issue has been reported. The workaround is to manually
+update the created ERF file to contain a single line per resource set
+with multiple ranks per line.
+
+
+jsrun latency priority capitalization allocates incorrect resources
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+jsrun's latency priority (``-l``) flag can be given lowercase values
+(i.e. gpu-cpu) or capitalized values (i.e. GPU-CPU).
+
+**Expected behavior**:
+
+    When capitalized, jsrun should not compromise on the resource layout,
+    and will wait to begin the job step until the ideal resources are
+    available. When given a lowercase value, jsrun will not wait, but
+    initiate the job step with the most ideal layout as is available at the
+    time. This also means that when there's no resource contention, such as
+    running a single job step at a time, capitalization should not matter,
+    as they should both yield the same resources.
+
+**Actual behavior**:
+
+    Capitalizing the latency priority value may allocate incorrect
+    resources, or even cause the job step to fail entirely.
+
+**Recommendation**:
+
+    It is currently recommended to only use the lowercase values to (``-l`` /
+    ``--latency_priority``). The system default is: gpu-cpu,cpu-mem,cpu-cpu.
+    Since this ordering is used implicitly when the ``-l`` flag is omitted, this
+    issue only impacts submissions which explicitly include a latency
+    priority in the jsrun command.
+
+Error when using complex datatypes with MPI Collectives and GPUDirect
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Users have reported errors when using complex datatypes with MPI
+Collectives and GPUDirect:
+
+::
+
+    jsrun --smpiargs="-gpu" -n 6 -a 1 -g 1   ./a.out
+    [h35n05:113506] coll:ibm:allreduce: GPU awareness in PAMI requested. It is not safe to defer to another component.
+    [h35n05:113506] *** An error occurred in MPI_Allreduce
+    [h35n05:113506] *** reported by process [3199551009,2]
+    [h35n05:113506] *** on communicator MPI_COMM_WORLD
+    [h35n05:113506] *** MPI_ERR_UNSUPPORTED_OPERATION: operation not supported
+    [h35n05:113506] *** MPI_ERRORS_ARE_FATAL (processes in this communicator will now abort,
+    [h35n05:113506] ***    and potentially your MPI job)
+    [h35n05:113509] coll:ibm:allreduce: GPU awareness in PAMI requested. It is not safe to defer to another component.
+
+This is a known issue with libcoll and the SMPI team is working to
+resolve it. In the meantime, a workaround is to treat the complex array
+as a real array with double the length if the operation is not
+MPI\_Prod. Note: This requires code modification. An alternative
+workaround is to disable IBM optimized collectives. This will impact
+performance however but requires no code changes and should be correct
+for all MPI\_Allreduce operations. You can do this by adding the
+following option to your jsrun command line:
+``--smpiargs="-HCOLL -FCA -mca coll_hcoll_enable 1 -mca coll_hcoll_np 0
+-mca coll ^basic -mca coll ^ibm -async"``
+
+Error when using ERF
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+`Explicit Resource Files
+<https://www.ibm.com/support/knowledgecenter/en/SSWRJV_10.1.0/jsm/10.3/base/erf_format.html>`__
+provide even more fine-granied control over how processes are mapped onto
+compute nodes.
+Users have reported errors when using ERF on Summit:
+
+::
+
+    Failed to bind process to ERF smt array, err: Invalid argument
+
+
+This is a known issue with the current version of jsrun.
+
+
+Resolved Issues
+---------------
+
+'Received msg header indicates a size that is too large' error message from Spectrum MPI
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+If you get an error message that looks like:
+
+::
+
+    A received msg header indicates a size that is too large:
+     Requested size: 25836785
+     Size limit: 16777216
+    If you believe this msg is legitimate, please increase the
+    max msg size via the ptl_base_max_msg_size parameter.
+
+This can be resolved by setting ``export PMIX_MCA_ptl_base_max_msg_size=18`` where the value is size in MB. Setting it to 18 or higher usually works. The default if its not explicitly set is around 16 MB. 
+
+JSM Fault Tolerance causes jobs to fail to start
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Adding ``FAULT_TOLERANCE=1`` in your individual ``~/.jsm.conf`` file,
+will result in LSF jobs failing to successfully start.
+
+
+The following issues were resolved with the July 16, 2019 software upgrade:
+
+
+Default nvprof setting clobbers ``LD_PRELOAD``, interfering with SpectrumMPI (Resolved: July 16, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+CUDA 10 adds a new feature to profile CPU side OpenMP constructs (see
+https://docs.nvidia.com/cuda/profiler-users-guide/index.html#openmp).
+This feature is enabled by default and has a bug which will cause it to
+overwrite the contents of ``LD_PRELOAD``. SpectrumMPI requires a library
+(``libpami_cuda_hook.so``) to be preloaded in order to function. All MPI
+applications on Summit will break when run in nvprof with default
+settings. The workaround is to disable the new OpenMP profiling feature:
+
+::
+
+    $ jsrun  nvprof --openmp-profiling off
+
+CSM-based launch is not currently supported (Resolved: July 16, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Users should not use ``JSMD_LAUNCH_MODE=csm`` in their ``~/.jsm.conf``
+file at this time. A bug has been filed with IBM to address this issue.
+
+--------------
+
+Parallel I/O crash on GPFS with latest MPI ROMIO
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In some cases with large number of MPI processes when there is not
+enough memory available on the compute node, the Abstract-Device
+Interface for I/O (ADIO) driver can break with this error:
+
+Out of memory
+in file
+../../../../../../../opensrc/ompi/ompi/mca/io/romio321/romio/adio/ad\_gpfs/ad\_gpfs\_rdcoll.c,
+line 1178
+
+The solution is to declare in your submission script:
+
+::
+
+    export GPFSMPIO_COMM=1
+
+This command will use non-blocking MPI calls and not MPI\_Alltoallv for
+exchange of data between the MPI I/O aggregators which requires
+significant more amount of memory.
+
+--------------
+
+The following issues were resolved
+with the May 21, 2019 upgrade:
+
+-g flag causes internal compiler error with XL compiler (Resolved: May 21, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Some users have reported an internal compiler error when compiling their
+code with XL with the \`-g\` flag. This has been reported to IBM and
+they are investigating.
+
+.. note::
+		This bug was fixed in xl/16.1.1-3
+
+Issue with CUDA Aware MPI with >1 resource set per node (Resolved: May 21, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Attempting to run an application with CUDA-aware MPI using more than one
+resource set per node with produce the following error on each MPI rank:
+
+::
+
+    /__SMPI_build_dir__________________________________________/ibmsrc/pami/ibm-pami/buildtools/pami_build_port/../pami/components/devices/ibvdevice/CudaIPCPool.h:300:
+    [0]Error opening IPC Memhandle from peer:1, invalid argument
+    CUDA level IPC failure: this has been observed in environments where cgroups separate the visible GPUs between ranks. The option -x PAMI_DISABLE_IPC=1 can be used to disable CUDA level IPC.[:] *** Process received signal ***
+
+Spectrum MPI relies on CUDA Inter-process Communication (CUDA IPC) to
+provide fast on-node between GPUs. At present this capability cannot
+function with more than one resource set per node.
+
+#. Set the environment variable ``PAMI_DISABLE_IPC=1`` to force Spectrum
+   MPI to not use fast GPU Peer-to-peer communication. This option will
+   allow your code to run with more than one resource set per host, but
+   you may see slower GPU to GPU communication.
+#. Run in a single resource set per host, i.e. with
+   ``jsrun --gpu_per_rs 6``
+
+If on-node MPI communication between GPUs is critical to your
+application performance, option B is recommended but you’ll need to set
+the GPU affinity manually. This could be done with an API call in your
+code (e.g. ``cudaSetDevice``), or by using a wrapper script.
+
+Simultaneous backgrounded jsruns (Resolved: May 21, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We have seen occasional errors from batch jobs with multiple
+simultaneous backgrounded jsrun commands. Jobs may see pmix errors
+during the noted failures. 
+
+--------------
+
+The following issue was resolved with the software default changes from
+March 12, 2019 that set Spectrum MPI 10.2.0.11 (20190201) as default and
+moved ROMIO to version 3.2.1:
+
+Slow performance using parallel HDF5 (Resolved: March 12, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A performance issue has been identified using parallel HDF5 with the
+default version of ROMIO provided in
+``spectrum-mpi/10.2.0.10-20181214``. To fully take advantage of parallel
+HDF5, users need to switch to the newer version of ROMIO and use ROMIO
+hints. The following shows recommended variables and hints for a 2 node
+job. Please note that hints must be tuned for a specific job.
+
+::
+
+    $ module unload darshan-runtime
+    $ export OMPI_MCA_io=romio321
+    $ export ROMIO_HINTS=./my_romio_hints
+    $ cat $ROMIO_HINTS
+    romio_cb_write enable
+    romio_ds_write enable
+    cb_buffer_size 16777216
+    cb_nodes 2
+
+Job hangs in MPI\_Finalize (Resolved: March 12, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There is a known issue in Spectrum MPI 10.2.0.10 provided by the
+``spectrum-mpi/10.2.0.10-20181214`` modulefile that causes a hang in
+``MPI_Finalize`` when ROMIO 3.2.1 is being used and the
+``darshan-runtime`` modulefile is loaded. The recommended and default
+Spectrum MPI version as of March 3, 2019 is Spectrum MPI 10.2.0.11
+provided by the ``spectrum-mpi/10.2.0.11-20190201`` modulefile. If you
+are seeing this issue, please make sure that you are using the latest
+version of Spectrum MPI. If you need to use a previous version of
+Spectrum MPI, your options are:
+
+-  Unload the ``darshan-runtime`` modulefile.
+-  Alternatively, set ``export OMPI_MCA_io=romio314`` in your
+   environment to use the previous version of ROMIO. Please note that
+   this version has known performance issues with parallel HDF5 (see
+   "Slow performance using parallel HDF5" issue below).
+
+--------------
+
+The following issues were resolved with the February 19, 2019 upgrade:
+
+Job step cgroups are not currently supported (Resolved: February 19, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+A regression was introduced in JSM 10.02.00.10rtm2 that prevents job
+step cgroups from being created as a result, JSM, is defaulting to
+setting ``CUDA_VISIBLE_DEVICES`` in order to allocate GPUs to specific
+resource sets. Because of this issue, even if using ``--gpu_per_rs 0``
+or ``-g 0``, every resource set in the step will be able to see all 6
+GPUs in a node.
+
+JSM stdio options do not create files (Resolved: February 19, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+When using ``--stdio_stdout`` or ``--stdio_stderr`` users must use
+absolute paths. Using relative paths (e.g. ``./my_stdout``) will not
+successfully create the file in the user's current working directory. An
+bug has been filed with IBM to fix this issue and allow relative paths.
+
+JSM crash when using different number of resource sets per host (Resolved: February 19, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+In some cases users will encounter a segmentation fault when running job
+steps that have uneven number of resource sets per node. For example:
+
+::
+
+    $ jsrun --nrs 41 -c 21 -a 1 --bind rs ./a.out
+    [a03n07:74208] *** Process received signal ***
+    [a03n07:74208] Signal: Segmentation fault (11)
+    [a03n07:74208] Signal code: Address not mapped (1)
+    [a03n07:74208] Failing at address: (nil)
+    ...
+
+As a workaround, two environment variables are set as default in the
+user environment ``PAMI_PMIX_USE_OLD_MAPCACHE=1`` and
+``OMPI_MCA_coll_ibm_xml_disable_cache=1``.
+
+CUDA 10.1 Known Issues
+----------------------
+
+Intermittent failures with \`nvprof\` (Identified: July 11, 2019)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+We are seeing an intermittent issue that causes an error when
+profiling a code using `nvprof` from CUDA 10.1.168. We have filed
+a bug with NVIDIA (NV bug 2645669) and they have reproduced the
+problem. An update will be posted when a fix becomes available.
+
+When this issue is encountered, the profiler will exit with the
+following error message:
+
+::
+
+    ==99756== NVPROF is profiling process 99756, command: ./a.out
+    ==99756== Error: Internal profiling error 4306:999.
+    ======== Profiling result:
+    ======== Metric result:
+
+MPI annotation may cause segfaults with applications using MPI\_Init\_thread
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Users on Summit can have MPI calls automatically annotated in ``nvprof``
+timelines using the ``nvprof --annotate-mpi openmpi`` option. If the
+user calls ``MPI_Init_thread`` instead of ``MPI_Init``, ``nvprof`` may
+segfault, as ``MPI_Init_thread`` is currently not being wrapped by
+``nvprof``. The current alternative is to build and follow the
+instructions from
+https://github.com/NVIDIA/cuda-profiler/tree/mpi_init_thread.
+
+cudaMemAdvise before context creation leads to a kernel panic
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+There is a (very rare) driver bug involving cudaManagedMemory that can
+cause a kernel panic. If you encounter this bug, please contact the
+`OLCF User Support <mailto:help@olcf.ornl.gov>`__ team. The easiest
+mitigation is for the user code to initialize a context on every GPU
+with which it intends to interact (for example by calling
+``cudaFree(0)`` while each device is active).
+
+Some uses of Thrust complex vectors fail at compile time with warnings of identifiers being ``undefined in device code``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+This issue comes from the fact that ``std::complex`` is not
+``__host__``/``__device__`` annotated, so all its functions are
+implicitly ``__host__``. There is a mostly simple workaround, assuming
+this is compiled as C++11: in ``complex.h`` and ``complex.inl``,
+annotate the functions that deal with ``std::complex`` as
+``__host__ __device__`` (they are the ones that are annotated only as
+``__host__`` right now), and then compile with
+``--expt-relaxed-constexpr``.
+
+Users that encounter this issue, can use
+the following workaround. copy the entirety of
+``${OLCF_CUDA_ROOT}/include/thrust`` to a private location, make the
+above edits to ``thrust/complex.h`` and
+``thrust/detail/complex/complex.inl``, and then add that to your include
+path:
+
+::
+
+    $ nvcc -ccbin=g++ --expt-relaxed-constexpr assignment.cu -I./
+
+A permanent fix of this issue is expected in the version of Thrust
+packed with CUDA 10.1 update 1
+
+Breakpoints in CUDA kernels recommendation
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+``cuda-gdb`` allows for breakpoints to be set inside CUDA kernels to
+inspect the program state on the GPU. This can be a valuable debugging
+tool but breaking inside kernels does incur significant overhead that
+should be included in your expected runtime.
+
+The time required to hit a breakpoint inside a CUDA kernel depends on
+how many CUDA threads are used to execute the kernel. It may take
+several seconds to stop at kernel breakpoints for very large numbers
+of threads. For this reason, it is recommended to choose breakpoints
+judiciously, especially when running the debugger in "batch" or
+"offline" mode where this overhead may be misperceived as the code
+hanging. If possible, debugging a smaller problem size with fewer
+active threads can be more pleasant.
+
+--------------
+
+.. _scalable-protected-infrastructure:
+
+Scalable Protected Infrastructure (SPI)
+=======================================
+
+The OLCF’s Scalable Protected Infrastructure (SPI) provides resources and protocols that enable researchers to process protected data at scale. The SPI is built around a framework of security protocols that allows researchers to process large datasets containing private information. Using this framework researchers can use the center’s large HPC resources to compute data containing protected health information (PHI), personally identifiable information (PII), data protected under International Traffic in Arms Regulations, and other types of data that require privacy.
+
+The SPI utilizes a mixture of existing resources combined with specialized resources targeted at SPI workloads. Because of this, many processes used within the SPI are very similar to those used for standard non-SPI. This page lists the differences you may see when using OLCF resources to execute SPI resources.
+
+The SPI provides access to the OLCF's Summit resource for compute.  To safely separate SPI and non-SPI workflows, SPI workflows must use a separate login node named :ref:`Citadel<spi-compute-citadel>`. Because Citadel is largely a front end for Summit, you can use the Summit documentation when using Citadel. The :ref:`SPI<spi-compute-citadel>` page can be used to see notable differences when using the Citadel resource.
+
+--------------
+
+.. _training-system-ascent:
+
+Training System (Ascent)
+========================
+
+.. note::
+    Ascent is a training system that is not intended to be used as
+    an OLCF user resource. Access to the system is only obtained through
+    OLCF training events.
+
+Ascent is an 18-node stand-alone system with the same architecture as
+Summit (see :ref:`summit-nodes` section above), so most of this Summit User Guide can be referenced for
+Ascent as well. However, aside from the number of compute nodes, there
+are other differences between the two systems. Most notably, Ascent sits
+in the NCCS Open Security Enclave, which is subject to fewer
+restrictions than the Moderate Security Enclave that systems such as
+Summit belong to. This means that participants in OLCF training events
+can go through a streamlined version of the approval process before
+gaining access to the system. The remainder of this section of the user
+guide describes "Ascent-specific" information intended for participants
+of OLCF training events.
+
+File Systems
+------------
+
+It is important to note that because Ascent sits in the NCCS Open
+Security Enclave, it also mounts different file systems than Summit.
+These file systems provide both user-affiliated and project-affiliated
+storage areas for each user.
+
+NFS Directories
+^^^^^^^^^^^^^^^
+
+Upon logging into Ascent, users will be placed in their own personal
+home (NFS) directory, ``/ccsopen/home/[userid]``, which can only be
+accessed by that user. Users also have access to an NFS project
+directory, ``/ccsopen/proj/[projid]``, which is visible to all members
+of a project. Both of these NFS directories are commonly used to store
+source code and build applications.
+
+GPFS Directories
+^^^^^^^^^^^^^^^^
+
+Users also have access to a (GPFS) parallel file system, called wolf,
+which is where data should be written when running on Ascent's compute
+nodes. Under ``/gpfs/wolf/[projid]``, there are 3 directories:
+
+::
+
+    $ ls /gpfs/wolf/[projid]
+    proj-shared  scratch  world-shared
+
+-  ``proj-shared`` can be accessed by all members of a project.
+-  ``scratch`` contains directories for each user of a project and only
+   that user can access their own directory.
+-  ``world-shared`` can be accessed by any users on the system in any
+   project.
+
+Obtaining Access to Ascent
+--------------------------
+
+.. note::
+    Ascent is a training system that is not intended to be used as
+    an OLCF user resource. Access to the system is only obtained through
+    OLCF training events.
+
+This sub-section describes the process of obtaining access to Ascent for
+an OLCF training event. Please follow the steps below to request access.
+
+Step 1: Go to the `myOLCF Account Application Form <https://my.olcf.ornl.gov/account-application-new>`__
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+1. Once on the form, linked above, fill in the project ID in the "Enter the Project ID of the project you wish to join" field and click "Next".
+
+.. image:: /images/ascent_start.png
+   :align: center
+
+2. After you enter the Project ID, use the sliders to select "Yes" for OLCF as the Project Organization and select "Yes" for Open as the Security Enclave.
+
+.. image:: /images/ascent_start2.png
+   :align: center
+
+
+3. The next screen will show you some information about the project, you don't need to change anything, just click "Next".
+
+4. Fill in your personal information and then click "Next".
+
+5. Fill in your shipping information and then click "Next".
+
+6. Fill in your Employment/Institution Information. If you are student please use your school affiliation for both "Employer" and "Funding Source". If you are a student and you do not see your school listed, choose "other" for both "Employer" and "Funding Source" and then manually enter your school affiliation in the adjacent fields.  Click “Next” when you are done.
+
+7. On the Project information screen fill the "Proposed Contribution to Project" with "Participating in OLCF training." Leave all the questions about the project set to "no" and click "Next".
+
+.. image:: /images/ascent_project.png
+   :align: center
+
+
+8. On the user account page, selected "yes" or "no" for the questions asking about any pre-existing account names. If this is your first account with us, leave those questions set to "no". Also enter your preferred shell. If you do not know which shell to use, select "/bin/bash". We can change this later if needed. Click "Next".
+
+9. On the "Policies & Agreements" page click the links to read the polices and then answer "Yes" to affirm you have read each. Certify your application by selecting "Yes" as well. Then Click "Submit."
+
+
+
+.. note::
+    After submitting your application, it will need to pass
+    through the approval process. Depending on when you submit, approval
+    might not occur until the next business day.
+
+Step 2: Set Your XCAMS/UCAMS Password
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Once approved, if you are a new user, your account will be created and
+an email will be sent asking you to set up a password. If you already
+had an XCAMS/UCAMS account, you will not be sent the email asking you to
+setup a new password (simply use your existing credentials). Once
+passwords are known, users can log in to Ascent using their XCAMS/UCAMS
+username and password (see the next section)
+
+Logging In to Ascent
+--------------------
+
+To log in to Ascent, please use your XCAMS/UCAMS username and password:
+
+``$ ssh USERNAME@login1.ascent.olcf.ornl.gov``
+
+.. note::
+    You do not need to use an RSA token to log in to Ascent.
+    Please use your XCAMS/UCAMS username and password (which is different
+    from the username and PIN + RSA token code used to log in to other OLCF
+    systems such as Summit).
+
+.. note::
+    It will take ~5 minutes for your directories to be created, so
+    if your account was just created and you log in and you do not have a
+    home directory, this is likely the reason.
+
+Preparing For Frontier
+======================
+
+This section of the Summit User Guide is intended to show current OLCF
+users how to start preparing their applications to run on the upcoming
+Frontier system. We will continue to add more topics to this section in
+the coming months. Please see the topics below to get started.
+
+HIP
+---
+
+HIP (Heterogeneous-Compute Interface for Portability) is a C++ runtime
+API that allows developers to write portable code to run on AMD and NVIDIA
+GPUs. It is an interface that uses the underlying Radeon Open Compute (ROCm)
+or CUDA platform that is installed on a system. The API is similar to CUDA
+so porting existing codes from CUDA to HIP should be fairly straightforward
+in most cases. In addition, HIP provides porting tools which can be used to
+help port CUDA codes to the HIP layer, with no overhead compared to the
+original CUDA application. HIP is not intended to be a drop-in replacement
+for CUDA, so some manual coding and performance tuning work should be
+expected to complete the port.
+
+Key features include:
+
+- HIP is a thin layer and has little or no performance impact over
+  coding directly in CUDA.
+
+- HIP allows coding in a single-source C++ programming language including
+  features such as templates, C++11 lambdas, classes, namespaces, and more.
+
+- The “hipify” tools automatically convert source from CUDA to HIP.
+
+- Developers can specialize for the platform (CUDA or HIP) to tune for
+  performance or handle tricky cases.
+
+Using HIP on Summit
+-------------------
+
+As mentioned above, HIP can be used on systems running on either the ROCm
+or CUDA platform, so OLCF users can start preparing their applications for
+Frontier today on Summit. To use HIP on Summit, you must load the HIP module:
+
+::
+
+    $ module load hip-cuda
+
+CUDA 11.4.0 or later must be loaded in order to load the hip-cuda module.
+hipBLAS, hipFFT, hipSOLVER, hipSPARSE, and hipRAND have also been added
+to hip-cuda.
+
+Learning to Program with HIP
+----------------------------
+
+The HIP API is very similar to CUDA, so if you are already familiar with
+using CUDA, the transition to using HIP should be fairly straightforward.
+Whether you are already familiar with CUDA or not, the best place to start
+learning about HIP is this Introduction to HIP webinar that was recently
+given by AMD:
+
+- **Introduction to AMD GPU Programming with HIP**:
+  (`slides <https://www.exascaleproject.org/wp-content/uploads/2017/05/ORNL_HIP_webinar_20190606_final.pdf>`__ | `recording <https://youtu.be/3ZXbRJVvgJs>`__)
+
+
+More useful resources, provided by AMD, can be found here:
+
+- `HIP Programming Guide <https://rocm-documentation.readthedocs.io/en/latest/Programming_Guides/HIP-GUIDE.html>`__
+
+- `HIP API Documentation <https://rocm-documentation.readthedocs.io/en/latest/ROCm_API_References/HIP-API.html>`__
+
+- `HIP Porting Guide <https://github.com/ROCm-Developer-Tools/HIP/blob/master/docs/markdown/hip_porting_guide.md>`__
+
+The OLCF is currently adding some simple HIP tutorials here as well:
+
+- OLCF Tutorials – `Simple HIP Examples <https://github.com/olcf-tutorials/simple_HIP_examples>`__
+
+Previous Frontier Training Events
+---------------------------------
+
+The links below point to event pages from previous Frontier training events. Under the "Presentations" tab on each event page, you will find the presentations given during the event.
+
+`Frontier Application Readiness Kick-Off Workshop (October 2019) <https://www.olcf.ornl.gov/frontier-application-readiness-kick-off-workshop/>`__
+
+Please check back to this section regularly as we will continue
+to add new content for our users.

--- a/systems/summit_user_guide.rst
+++ b/systems/summit_user_guide.rst
@@ -1,23 +1,14 @@
+:no-search:
 .. _summit-user-guide:
 
 ******************
 Summit User Guide
 ******************
 
-.. note::
+.. warning::
 
-  Notable changes to Summit for 2024 allocations:
-
-  Alpine Decomissioned (Jan 01, 2024)
-    Summit's previous scratch filesystem, Alpine, was decommissioned on January 01, 2024.
-
-  New Scratch Filesystem Available (Alpine2)
-    Alpine2, Summit's new GPFS scratch filesystem is now available to replace the previous scratch filesystem.  The new filesystem is mounted on Summit, Andes, and the DTNs.  Returning users will need to transfer data onto Apline2 since data on the previous scratch filesystem is no longer available.
-
-  Software Updates
-    Summit's software has been updated.  Returning users should recompile prior to running.  A list of default software updates can be found on https://docs.olcf.ornl.gov/software/software-news.html . Please note the previous software stack remains available and can be accessed by loading the DefApps-2023 modulefile. For convenience, a DefApps-2024 is also provide to restore the most recent version of packages.
-
-
+  This system was decommissioned on November 15, 2024 and is no longer online.
+  Information here is presented as an archive and is no longer updated.
 
 .. _summit-documentation-resources:
 


### PR DESCRIPTION
Adds legacy guides, but keeps their URLs the same as they were originally (thus preserving links included in publications). Their content doesn't add them to the search index when building as an effort to not bloat search functionality / mislead users to outdated info.